### PR TITLE
Renamed cli.CliFlags to cli.Flags

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package cli
 
-// CliFlags represents structure holding all command line arguments and flags.
-type CliFlags struct {
+// Flags represents structure holding all command line arguments and flags.
+type Flags struct {
 	ShowConfiguration bool
 	ShowAuthors       bool
 	ShowVersion       bool

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	doSelectedOperation(cliFlags)
 }
 
-func parseFlags() (cliFlags cli.CliFlags) {
+func parseFlags() (cliFlags cli.Flags) {
 	flag.BoolVar(&cliFlags.ShowConfiguration, "show-configuration", false, "show configuration")
 	flag.BoolVar(&cliFlags.ShowAuthors, "show-authors", false, "show authors")
 	flag.BoolVar(&cliFlags.ShowVersion, "show-version", false, "show version")
@@ -59,7 +59,7 @@ func parseFlags() (cliFlags cli.CliFlags) {
 	return
 }
 
-func doSelectedOperation(cliFlags cli.CliFlags) {
+func doSelectedOperation(cliFlags cli.Flags) {
 	switch {
 	case cliFlags.ShowConfiguration:
 		cli.PrintConfiguration(config.Config)


### PR DESCRIPTION
# Description

Renamed `cli.CliFlags` to `cli.Flags`

Fixes #28

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Use `golint`

## Checklist
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
