### PR TITLE
Rules version shouldn't be hardcoded

### DIFF
--- a/internal/service/common_test.go
+++ b/internal/service/common_test.go
@@ -20,6 +20,7 @@ import "github.com/RedHatInsights/insights-operator-gathering-conditions-service
 
 var (
 	validRules = service.Rules{
+		Version: "0.0.1",
 		Items: []service.Rule{
 			{
 				Conditions: []interface{}{
@@ -32,6 +33,7 @@ var (
 	}
 	validRulesJSON = `
 	{
+		"version": "0.0.1",
 		"rules": [
 			{
 				"conditions": ["condition 1", "condition 2"],

--- a/internal/service/endpoints.go
+++ b/internal/service/endpoints.go
@@ -48,7 +48,7 @@ func gatheringRulesEndpoint(svc Interface) http.HandlerFunc {
 
 		log.Info().Int("rules count", len(rules.Items)).Msg("Serving gathering rules")
 		renderResponse(w, &GatheringRulesResponse{
-			Version: "1.0",
+			Version: rules.Version,
 			Rules:   rules.Items,
 		}, http.StatusOK)
 	}

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -34,7 +34,8 @@ type Rule struct {
 
 // Rules data type definition based on original JSON schema
 type Rules struct {
-	Items []Rule `json:"rules,omitempty"`
+	Items   []Rule `json:"rules,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // Repository is definition of objects that implement the RepositoryInterface

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -77,7 +77,7 @@ func TestService(t *testing.T) {
 			assert.Contains(
 				t,
 				rr.Body.String(),
-				`"version":"1.0","rules":[{"conditions":["condition 1","condition 2"],"gathering_functions":"the gathering functions"}]`)
+				`"version":"0.0.1","rules":[{"conditions":["condition 1","condition 2"],"gathering_functions":"the gathering functions"}]`)
 		}
 	}
 

--- a/internal/service/testdata/rules.json
+++ b/internal/service/testdata/rules.json
@@ -1,4 +1,5 @@
 {
+    "version":"0.0.1",
     "rules": [
         {
             "conditions": [

--- a/tests/conditions/rules.json
+++ b/tests/conditions/rules.json
@@ -1,4 +1,6 @@
-{"rules":
+{
+    "version": "1.0",
+    "rules":
     [
         {
             "conditions": [

--- a/tests/rest/rules_endpoint.go
+++ b/tests/rest/rules_endpoint.go
@@ -52,7 +52,7 @@ func readGatheringRules(f *frisby.Frisby) Payload {
 // checkResponse checks if the payload returned by server has proper format
 func checkResponse(f *frisby.Frisby, response Payload) {
 	if response.Version != "1.0" {
-		f.AddError("Improper 'version' attribute returned")
+		f.AddError("Improper 'version' attribute returned: " + response.Version)
 	}
 
 	rules := response.Rules


### PR DESCRIPTION
# Description

Adding a version attribute to the `Rules` type so that the version is correctly propagated. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Just check the version in the `rules.json` vs what the running service is returning

## Checklist
* [ ] updated documentation wherever necessary
* [X] added or modified tests if necessary
