### PR TITLE
specify condition repository version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,19 @@
 ###################
 # Conditions
 ###################
-FROM quay.io/cloudservices/io-gathering-conditions:qa AS conditions
+
+FROM registry.redhat.io/ubi8/ubi-minimal:latest AS conditions
+
+ARG CONDITIONS_VERSION="0.1.0"
+
+RUN microdnf install --nodocs -y jq git
+
+RUN git clone --depth 1 --branch $CONDITIONS_VERSION https://github.com/RedHatInsights/insights-operator-gathering-conditions
+
+WORKDIR "/insights-operator-gathering-conditions"
+
+RUN ./build.sh && \
+    cp -r ./build/* /conditions
 
 ###################
 # Builder


### PR DESCRIPTION
# Description
this change allows developers to specify a https://github.com/RedHatInsights/insights-operator-gathering-conditions version when building the image


## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
