### PR TITLE
unit test for environment variables

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ environment = "dev"
 [logging]
 debug = true
 log_level="debug"
-logging_to_cloudwatch_enabled = false
+logging_to_cloud_watch_enabled = false
 logging_to_sentry_enabled = true
 logging_to_kafka_enabled = false
 
@@ -26,3 +26,13 @@ broker = ""
 topic = ""
 cert_path = ""
 level = ""
+
+[cloudwatch]
+aws_access_id = "a key id"
+aws_secret_key = "tshhhh it is a secret"
+aws_session_token = ""
+aws_region = "us-east-1"
+log_group = "platform-dev"
+stream_name = "io-gathering-service"
+debug = false
+create_stream_if_not_exists = false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,6 +150,22 @@ func TestLoadConfiguration(t *testing.T) {
 
 }
 
+func TestEnvVarsOverride(t *testing.T) {
+	os.Clearenv()
+	err := os.Setenv("INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__CLOUDWATCH__DEBUG", "true")
+	assert.Equal(t, err, nil)
+	err = os.Setenv("INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED", "true")
+	assert.Equal(t, err, nil)
+	err = os.Setenv("INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__SERVER__ADDRESS", ":0888")
+	assert.Equal(t, err, nil)
+	err = config.LoadConfiguration(validConfPath)
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, config.Config.ServerConfig.Address, ":0888")
+	assert.Equal(t, config.Config.LoggingConfig.LoggingToCloudWatchEnabled, true)
+	assert.Equal(t, config.Config.CloudWatchConfig.Debug, true)
+}
+
 func TestGetConfigFunctions(t *testing.T) {
 	os.Clearenv()
 	assert.NoError(t, config.LoadConfiguration(validConfPath))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -158,10 +158,16 @@ func TestEnvVarsOverride(t *testing.T) {
 	assert.Equal(t, err, nil)
 	err = os.Setenv("INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__SERVER__ADDRESS", ":0888")
 	assert.Equal(t, err, nil)
+	err = os.Setenv("INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__STORAGE__RULES_PATH", "/test_path")
+	assert.Equal(t, err, nil)
+	err = os.Setenv("INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__SENTRY__DSN", "test_dsn")
+	assert.Equal(t, err, nil)
 	err = config.LoadConfiguration(validConfPath)
 	assert.Equal(t, err, nil)
 
 	assert.Equal(t, config.Config.ServerConfig.Address, ":0888")
+	assert.Equal(t, config.Config.StorageConfig.RulesPath, "/test_path")
+	assert.Equal(t, config.Config.SentryLoggingConfig.SentryDSN, "test_dsn")
 	assert.Equal(t, config.Config.LoggingConfig.LoggingToCloudWatchEnabled, true)
 	assert.Equal(t, config.Config.CloudWatchConfig.Debug, true)
 }

--- a/internal/config/testdata/valid-config.toml
+++ b/internal/config/testdata/valid-config.toml
@@ -18,3 +18,9 @@ broker = "broker"
 topic = "topic"
 cert_path = "cert_path"
 level = "level"
+
+[logging]
+logging_to_cloud_watch_enabled = false 
+
+[cloudwatch]
+debug = false


### PR DESCRIPTION
# Description

setting environment variables like `INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED` or `INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__CLOUDWATCH__DEBUG` (probably others) does not produce any effect. This unit test is for highlight the problem

Fixes CCXDEV-7580

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

tun the unit test , the last 2 asserts will fail

## Checklist
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
