### PR TITLE
do not debug cloudwatch

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -166,7 +166,7 @@ parameters:
   value: "true"
   required: true
 - name: CLOUDWATCH_DEBUG
-  value: "true"
+  value: "false"
   required: true
 - name: IOGCS_LOG_STREAM
   value: $HOSTNAME


### PR DESCRIPTION
# Description
we don't need to debug cloud watch anymore, disabling the option

Fixes CCXDEV-7580

## Type of change

Please delete options that are not relevant.


- New feature (non-breaking change which adds functionality)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
