### PR TITLE
[CCXDEV-8201] Disable minimum-thre-replicas kube-linter check

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -38,6 +38,8 @@ objects:
   kind: ClowdApp
   metadata:
     name: io-gathering-service
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "This app doesn't have that much traffic"
   spec:
     envName: ${ENV_NAME}
     testing:


### PR DESCRIPTION
# Description

Disable the minimum-three-replicas kubelinter check.

## Type of change

- Deployment (no changes in the code)

## Testing steps

I tested this with the content-service and worked.

## Checklist
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
