### PR TITLE
Use Go 1.17 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 
 language: go
 go:
-- "1.16"
+- "1.17"
 
 jobs:
   include:


### PR DESCRIPTION
# Description

Use Go 1.17 on CI

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
