### PR TITLE
Replace params with alert in tests and OpenAPI spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -74,7 +74,7 @@
                             "items": {
                               "type": "object",
                               "properties": {
-                                "params": {
+                                "alert": {
                                   "type": "object",
                                   "properties": {
                                     "name": {
@@ -90,7 +90,7 @@
                                 }
                               },
                               "required": [
-                                "params",
+                                "alert",
                                 "type"
                               ]
                             }
@@ -115,7 +115,7 @@
                           "conditions": [
                             {
                               "type": "alert_is_firing",
-                              "params": {
+                              "alert": {
                                 "name": "SamplesImagestreamImportFailing"
                               }
                             }
@@ -211,7 +211,7 @@
                             "items": {
                               "type": "object",
                               "properties": {
-                                "params": {
+                                "alert": {
                                   "type": "object",
                                   "properties": {
                                     "name": {
@@ -227,7 +227,7 @@
                                 }
                               },
                               "required": [
-                                "params",
+                                "alert",
                                 "type"
                               ]
                             }
@@ -252,7 +252,7 @@
                           "conditions": [
                             {
                               "type": "alert_is_firing",
-                              "params": {
+                              "alert": {
                                 "name": "SamplesImagestreamImportFailing"
                               }
                             }

--- a/tests/conditions/rules.json
+++ b/tests/conditions/rules.json
@@ -6,7 +6,7 @@
             "conditions": [
                 {
                     "type": "alert_is_firing",
-                    "params": {
+                    "alert": {
                         "name": "SamplesImagestreamImportFailing"
                     }
                 }


### PR DESCRIPTION
# Description

OpenAPI and data in tests do not match the structure of real data. This fix replaces `params` attribute with `alert`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run the unit tests.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
