### PR TITLE
[CCXDEV-12944] Log the headers of the request (not the authorization one)

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -104,6 +104,8 @@ objects:
                   optional: true
             - name: INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__SENTRY__ENVIRONMENT
               value: ${ENV_NAME}
+            - name: INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__LOGGING__LOG_LEVEL
+              value: ${LOG_LEVEL}
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             failureThreshold: 3
@@ -190,3 +192,5 @@ parameters:
   value: '200m'
 - name: MEMORY_LIMIT
   value: '512Mi'
+- name: LOG_LEVEL
+  value: "INFO"

--- a/internal/service/endpoints.go
+++ b/internal/service/endpoints.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"slices"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -117,9 +116,18 @@ func renderErrorResponse(w http.ResponseWriter, msg string, err error) {
 
 func logHeaders(r *http.Request, skipHeaders []string, logEvent *zerolog.Event) {
 	for name, values := range r.Header {
-		if slices.Contains(skipHeaders, name) {
+		if sliceContains(skipHeaders, name) {
 			continue
 		}
 		logEvent.Strs(name, values)
 	}
+}
+
+func sliceContains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/endpoints_test.go
+++ b/internal/service/endpoints_test.go
@@ -81,8 +81,6 @@ func TestLogHeaders(t *testing.T) {
 	req.Header.Add("User-Agent", "Go-http-client/1.1")
 
 	t.Run("no filter", func(t *testing.T) {
-		want := `{"level":"debug","Authorization":["Bearer token"],"Content-Type":["application/json"],"User-Agent":["Go-http-client/1.1"],"message":"test"}
-`
 		logs := &logSink{}
 		logger := zerolog.New(logs)
 		logEvent := logger.Debug()
@@ -91,13 +89,13 @@ func TestLogHeaders(t *testing.T) {
 		logEvent.Msg("test")
 
 		assert.Len(t, logs.logs, 1, "received more than 1 log")
-		assert.Equal(t, want, logs.logs[0])
+		got := logs.logs[0]
+		assert.Contains(t, got, `"Authorization":["Bearer token"]`)
+		assert.Contains(t, got, `"User-Agent":["Go-http-client/1.1"]`)
+		assert.Contains(t, got, `"Content-Type":["application/json"]`)
 	})
 
 	t.Run("with filter", func(t *testing.T) {
-		// Note that "Authorization":["Bearer token"] is no longer expected
-		want := `{"level":"debug","Content-Type":["application/json"],"User-Agent":["Go-http-client/1.1"],"message":"test"}
-`
 		logs := &logSink{}
 		logger := zerolog.New(logs)
 		logEvent := logger.Debug()
@@ -106,7 +104,10 @@ func TestLogHeaders(t *testing.T) {
 		logEvent.Msg("test")
 
 		assert.Len(t, logs.logs, 1, "received more than 1 log")
-		assert.Equal(t, want, logs.logs[0])
+		got := logs.logs[0]
+		// Note that "Authorization":["Bearer token"] is no longer expected
+		assert.Contains(t, got, `"User-Agent":["Go-http-client/1.1"]`)
+		assert.Contains(t, got, `"Content-Type":["application/json"]`)
 	})
 }
 

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -25,4 +25,7 @@ package service
 // Please look into the following blogpost:
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd
 // to see why this trick is needed.
-var RenderResponse = renderResponse
+var (
+	RenderResponse = renderResponse
+	LogHeaders     = logHeaders
+)


### PR DESCRIPTION
# Description

We need to check if we receive the Cluster ID from the Insights Operator. These debug logs will print all the headers we receive per request. As the debug level on stage and prod is INFO, this will not increase the current amount of logs but rather be enabled by changing the corresponding environment variable.

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Configuration update

## Testing steps

- `go test -v -run TestLogHeaders ./internal/service/...`
- CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
