### PR TITLE
[CCXDEV-12944] Just log the wanted headers: User-Agent

### DIFF
--- a/internal/service/endpoints.go
+++ b/internal/service/endpoints.go
@@ -52,7 +52,7 @@ func gatheringRulesEndpoint(svc Interface) http.HandlerFunc {
 		// This is some debug logging to check if we receive the cluster ID as
 		// part of the request IO is doing
 		logHeadersEvent := log.Debug()
-		logHeaders(r, []string{"Authorization"}, logHeadersEvent)
+		logHeaders(r, []string{"User-Agent"}, logHeadersEvent)
 		logHeadersEvent.Msg("Request headers")
 
 		rules, err := svc.Rules()

--- a/internal/service/endpoints.go
+++ b/internal/service/endpoints.go
@@ -114,12 +114,11 @@ func renderErrorResponse(w http.ResponseWriter, msg string, err error) {
 	renderResponse(w, resp, code)
 }
 
-func logHeaders(r *http.Request, skipHeaders []string, logEvent *zerolog.Event) {
+func logHeaders(r *http.Request, wantHeaders []string, logEvent *zerolog.Event) {
 	for name, values := range r.Header {
-		if sliceContains(skipHeaders, name) {
-			continue
+		if sliceContains(wantHeaders, name) {
+			logEvent.Strs(name, values)
 		}
-		logEvent.Strs(name, values)
 	}
 }
 

--- a/internal/service/endpoints_test.go
+++ b/internal/service/endpoints_test.go
@@ -90,9 +90,9 @@ func TestLogHeaders(t *testing.T) {
 
 		assert.Len(t, logs.logs, 1, "received more than 1 log")
 		got := logs.logs[0]
-		assert.Contains(t, got, `"Authorization":["Bearer token"]`)
-		assert.Contains(t, got, `"User-Agent":["Go-http-client/1.1"]`)
-		assert.Contains(t, got, `"Content-Type":["application/json"]`)
+		assert.NotContains(t, got, `"Authorization":["Bearer token"]`)
+		assert.NotContains(t, got, `"User-Agent":["Go-http-client/1.1"]`)
+		assert.NotContains(t, got, `"Content-Type":["application/json"]`)
 	})
 
 	t.Run("with filter", func(t *testing.T) {
@@ -100,14 +100,15 @@ func TestLogHeaders(t *testing.T) {
 		logger := zerolog.New(logs)
 		logEvent := logger.Debug()
 
-		service.LogHeaders(req, []string{"Authorization"}, logEvent)
+		service.LogHeaders(req, []string{"User-Agent"}, logEvent)
 		logEvent.Msg("test")
 
 		assert.Len(t, logs.logs, 1, "received more than 1 log")
 		got := logs.logs[0]
-		// Note that "Authorization":["Bearer token"] is no longer expected
+		// Note that just "User-Agent" is expected
 		assert.Contains(t, got, `"User-Agent":["Go-http-client/1.1"]`)
-		assert.Contains(t, got, `"Content-Type":["application/json"]`)
+		assert.NotContains(t, got, `"Authorization"`)
+		assert.NotContains(t, got, `"Content-Type"`)
 	})
 }
 


### PR DESCRIPTION
# Description

I tried on stage and Akamai is adding plenty of headers (some with secrets too), so let's filter those. We just need to check the User-Agent: https://github.com/openshift/insights-operator/blob/b718b248843b5b3b57cabda770442991f54ba0ec/pkg/insights/insightsclient/insightsclient.go#L158

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

UTs

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
