### PR TITLE
[CCXDEV-13025] Use proper url to RH image registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Conditions
 ###################
 
-FROM registry.redhat.io/ubi8/ubi-minimal:latest AS conditions
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS conditions
 
 ARG CONDITIONS_VERSION="1.0.1"
 


### PR DESCRIPTION
# Description

For migrating image building to Konflux, the old url to RH image registry does not work. This fixes image building for konflux.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
