### PR TITLE
[CCXDEV-13025] One more fix for url to RH image registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ./build.sh && \
 ###################
 # Builder
 ###################
-FROM registry.redhat.io/rhel8/go-toolset:1.18 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
 
 USER 0
 


### PR DESCRIPTION

## Description
For migrating image building to Konflux, the old url to RH image registry does not work. This fixes image building for konflux.

## Type of change

* Bug fix (non-breaking change which fixes an issue)