### PR TITLE
[CCXDEV-13146] Replace cache map with thread safe solution

### DIFF
--- a/internal/service/storage.go
+++ b/internal/service/storage.go
@@ -44,12 +44,12 @@ type Cache struct {
 }
 
 // Get retrieves value from the cache
-func (c *Cache) Get(key string) ([]byte, bool) {
-	data, ok := c.cache.Load(key)
+func (c *Cache) Get(key string) []byte {
+	data, _ := c.cache.Load(key)
 	if data != nil {
-		return data.([]byte), ok
+		return data.([]byte)
 	}
-	return nil, ok
+	return nil
 }
 
 // Set stores value under given key to the cache
@@ -89,8 +89,8 @@ func (s *Storage) ReadRemoteConfig(path string) []byte {
 
 func (s *Storage) readDataFromPath(path string) []byte {
 	// use the in-memory data
-	data, ok := s.cache.Get(path)
-	if ok {
+	data := s.cache.Get(path)
+	if data != nil {
 		return data
 	}
 

--- a/internal/service/storage.go
+++ b/internal/service/storage.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 )
@@ -37,11 +38,30 @@ type StorageConfig struct {
 	RemoteConfigurationPath string `mapstructure:"remote_configuration" toml:"remote_configuration"`
 }
 
+// Cache type represents thread safe map for storing loaded configurations
+type Cache struct {
+	cache sync.Map
+}
+
+// Get retrieves value from the cache
+func (c *Cache) Get(key string) ([]byte, bool) {
+	data, ok := c.cache.Load(key)
+	if data != nil {
+		return data.([]byte), ok
+	}
+	return nil, ok
+}
+
+// Set stores value under given key to the cache
+func (c *Cache) Set(key string, value []byte) {
+	c.cache.Store(key, value)
+}
+
 // Storage type represents container for resources.
 type Storage struct {
 	conditionalRulesPath    string
 	remoteConfigurationPath string
-	cache                   map[string][]byte
+	cache                   Cache
 }
 
 // NewStorage constructs new storage object.
@@ -50,7 +70,6 @@ func NewStorage(cfg StorageConfig) *Storage {
 	return &Storage{
 		conditionalRulesPath:    cfg.RulesPath,
 		remoteConfigurationPath: cfg.RemoteConfigurationPath,
-		cache:                   make(map[string][]byte), // TODO: Make it an own type
 	}
 }
 
@@ -70,7 +89,7 @@ func (s *Storage) ReadRemoteConfig(path string) []byte {
 
 func (s *Storage) readDataFromPath(path string) []byte {
 	// use the in-memory data
-	data, ok := s.cache[path]
+	data, ok := s.cache.Get(path)
 	if ok {
 		return data
 	}
@@ -105,7 +124,7 @@ func (s *Storage) readFile(path string) ([]byte, error) {
 	}
 
 	// add the bytes to cache
-	s.cache[path] = data
+	s.cache.Set(path, data)
 
 	return data, nil
 }


### PR DESCRIPTION
# Description

There is a race condition in a cache mechanism used in this service. The original map is replaces with thread safe type.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

The service runs as usual.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
