### PR TITLE
Build with Go 1.21 and proper version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
 
 USER 0
 
+ENV GOFLAGS="-buildvcs=false"
+
 COPY . .
 
 RUN make build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN ./build.sh && \
 ###################
 # Builder
 ###################
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.21.11-1.1720406008 AS builder
 
 USER 0
 

--- a/build.sh
+++ b/build.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# this is improper - we need to start using tags in GitHub properly
-version=0.1
+# retrieve the latest tag set in repository
+version=$(git describe --always --tags --abbrev=0)
 
 buildtime=$(date)
 branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
# Description

- Use proper VCS version when possible, or latest commit if not
- Set `buildvcs` to false when building image in Docker (we don't care about tagging the build with a version)
- Use Go 1.21 as builder as some modules require it

Fixes #240 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
