### PR TITLE
Serve OpenAPI spec under v2

### DIFF
--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -50,6 +50,7 @@ func (s *Handler) Register(r *mux.Router) {
 	r.Handle(APIPrefix+"/gathering_rules", gatheringRulesEndpoint(s.svc)).Methods("GET")
 	r.HandleFunc(APIPrefix+V1Prefix+"/openapi.json", serveOpenAPI).Methods("GET")
 	r.Handle(APIPrefix+V1Prefix+"/gathering_rules", gatheringRulesEndpoint(s.svc)).Methods("GET")
+	r.HandleFunc(APIPrefix+V2Prefix+"/openapi.json", serveOpenAPI).Methods("GET")
 
 	v2Path := fmt.Sprintf("%s%s/{ocpVersion}/gathering_rules", APIPrefix, V2Prefix)
 	r.Handle(v2Path, remoteConfigurationEndpoint(s.svc)).Methods("GET")

--- a/internal/service/handler_test.go
+++ b/internal/service/handler_test.go
@@ -33,6 +33,7 @@ func TestWrongMethods(t *testing.T) {
 		"/gathering_rules",
 		"/v1/gathering_rules",
 		"/v1/openapi.json",
+		"/v2/openapi.json",
 		"/v2/1.2.3/gathering_rules",
 	}
 


### PR DESCRIPTION
# Description

Serve OpenAPI spec under v2 as it is now in v1.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Endpoint is available when run locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
