### PR TITLE
Update default image

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -164,7 +164,7 @@ objects:
 parameters:
 - description: Image name
   name: IMAGE
-  value: quay.io/redhat-services-prod/obsint-processing-tenant/io-gathering-service/io-gathering-service
+  value: quay.io/redhat-services-prod/obsint-processing-tenant/io-gathering-service
 - description: Image tag
   name: IMAGE_TAG
   required: true


### PR DESCRIPTION
# Description

Point to correct location where Konflux will push release images.

This will only work once releasing has been properly setup in Konflux. Currently there are no images there.

## Type of change

- Configuration update
