### PR TITLE
Return 404 if the ocp version is lower than the minimum version in the config map

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -143,6 +143,15 @@ func (*NoBodyError) Error() string {
 	return "client didn't provide request body"
 }
 
+// NotFoundError meaning that the requested resource wasn't found
+type NotFoundError struct {
+	ErrString string
+}
+
+func (e *NotFoundError) Error() string {
+	return e.ErrString
+}
+
 // ValidationError validation error, for example when string is longer then expected
 type ValidationError struct {
 	ParamName  string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -128,6 +128,8 @@ func HandleServerError(writer http.ResponseWriter, err error) {
 	switch err := err.(type) {
 	case *errors.RouterMissingParamError, *errors.RouterParsingError, *errors.NoBodyError, *errors.ValidationError:
 		respErr = SendBadRequest(writer, err.Error())
+	case *errors.NotFoundError:
+		respErr = SendNotFound(writer, err.Error())
 	case *json.UnmarshalTypeError:
 		respErr = SendBadRequest(writer, "bad type in json data")
 	case *errors.UnauthorizedError:

--- a/internal/service/cluster_mapping.go
+++ b/internal/service/cluster_mapping.go
@@ -85,10 +85,8 @@ func (cm ClusterMapping) GetFilepathForVersion(ocpVersionParsed semver.Version) 
 			Str("version", firstVersion.String()).
 			Str("ocpVersion", ocpVersionParsed.String()).
 			Msg(errMsg)
-		return "", &merrors.RouterParsingError{
-			ParamName:  "ocpVersion",
-			ParamValue: ocpVersionParsed.String(),
-			ErrString:  errMsg}
+		return "", &merrors.NotFoundError{
+			ErrString: errMsg}
 	} else if comparison == 0 {
 		return cm[0][1], nil
 	}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -157,6 +157,7 @@ func TestServiceV2WithClusterMapping(t *testing.T) {
 		ocpVersion             string
 		wantConfiguration      string
 		expect400              bool
+		expect404              bool
 	}
 
 	const (
@@ -201,7 +202,7 @@ func TestServiceV2WithClusterMapping(t *testing.T) {
 			clusterMappingFilepath: validClusterMapping,
 			expectedAnError:        false,
 			ocpVersion:             "1.2.3",
-			expect400:              true,
+			expect404:              true,
 		},
 		{
 			name:                   "cluster version is 4.0.0",
@@ -308,6 +309,8 @@ func TestServiceV2WithClusterMapping(t *testing.T) {
 
 			if tc.expect400 {
 				assert.Equal(t, http.StatusBadRequest, rr.Code)
+			} else if tc.expect404 {
+				assert.Equal(t, http.StatusNotFound, rr.Code)
 			} else {
 				assert.Equal(t, http.StatusOK, rr.Code)
 				assert.JSONEq(t, tc.wantConfiguration, rr.Body.String())


### PR DESCRIPTION
# Description

This was requested in [this discussion](https://github.com/RedHatInsights/insights-operator-gathering-conditions-service/pull/266#discussion_r1724866558) but I forgot to implement it. Luckily for us, it was detected by [this test](https://github.com/RedHatInsights/insights-operator-gathering-conditions-service/pull/269/checks?check_run_id=29420733277) (thanks @ikerreyes ).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Locally + CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
