### PR TITLE
CCXDEV-13089] Add the version to the io_gathering_remote_configuration metric

### DIFF
--- a/internal/service/metrics.go
+++ b/internal/service/metrics.go
@@ -10,5 +10,5 @@ var (
 			Name: "io_gathering_remote_configuration",
 			Help: "The number of times a remote configuration was returned",
 		},
-		[]string{"file"})
+		[]string{"file", "version"})
 )

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -101,7 +101,7 @@ func (r *Repository) RemoteConfiguration(ocpVersion string) (*RemoteConfiguratio
 	}
 
 	// Count the number of times a given remote configuration is returned
-	remoteConfigurationsMetric.WithLabelValues(filepath).Inc()
+	remoteConfigurationsMetric.WithLabelValues(filepath, remoteConfig.Version).Inc()
 
 	return &remoteConfig, nil
 }


### PR DESCRIPTION
# Description

Adding the version to the `io_gathering_remote_configuration` metric. This way we will be able to compare with https://github.com/RedHatInsights/insights-ccx-messaging/pull/252

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

```
❯ curl -s http://localhost:8000/api/gathering/v2/4.17.0/gathering_rules
{"conditional_gathering_rules":[{"conditions":[{"alert":{"name":"Experimental2"},"type":"alert_is_firing"}],"gathering_functions":{"containers_logs":{"alert_name":"Experimental2","container":"experimental2","tail_lines":50}}}],"container_logs":[],"version":"1.1.0"}%                                                                                                    
❯ curl http://localhost:8000/metrics
# HELP io_gathering_remote_configuration The number of times a remote configuration was returned
# TYPE io_gathering_remote_configuration counter
io_gathering_remote_configuration{file="experimental_2.json",version="1.1.0"} 1
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
