### PR TITLE
[CCXDEV-13091] Add canary rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The image contains stable and canary versions of configurations. Exact values of
 in `get_conditions.sh` script and should be changed each time we want release a new conditions version.
 Unfortunatelly it is not possible to change these values in the app-interface, because the change requires image rebuild.
 
+## Canary rollout
+
+Service provides option of canary rollout for new version of configurations. The image contains two different versions of configurations (`stable` and `canary`) and serves one of them depending on cluster ID retrieved from request header. The ratio of cluster IDs being served `stable` version opposed to `canary` is defined in the Unleash instance - `insights.unleash.devshift.net` for production environment and `insights-stage.unleash.devshift.net` for stage environment. We do not have Unleash instance that could be used in ephemeral.
+
 ## Configure
 
 Configuration is done by `toml` config, taking the `config/config.toml` in the working directory if no other configuration is provided. This can be overriden by `INSIGHTS_OPERATOR_CONDITIONAL_SERVICE_CONFIG_FILE` environment variable.

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,8 @@ type = "jwt"
 rules_path = "./conditions"
 remote_configuration = "./remote-configurations"
 cluster_mapping = "cluster-mapping.json"
+
+[canary]
 unleash_enabled = false
 unleash_url = "https://insights.unleash.devshift.net/api"
 unleash_token = ""

--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,11 @@ type = "jwt"
 rules_path = "./conditions"
 remote_configuration = "./remote-configurations"
 cluster_mapping = "cluster-mapping.json"
+unleash_enabled = false
+unleash_url = "https://insights.unleash.devshift.net/api"
 unleash_token = ""
+unleash_app = "default"
+unleash_toggle = "insights-operator-gathering-conditions-service"
 
 [sentry]
 dsn = "https://daca7436565e4580a85102b9ede9a177@sentry.devshift.net/1020"

--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,17 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Unleash/unleash-client-go/v4 v4.1.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/redhatinsights/app-common-go v1.6.8 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/twmb/murmur3 v1.1.8 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291 h1:f2RIq2LvG0Nz7TrPYr8clzUPXIEf+Q3oDoCfAHym4/I=
 github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291/go.mod h1:8l+HqU8iWM6hA9kSAHgY3ItSlpEsPr8fb2R0GBp9S0U=
 github.com/RedHatInsights/insights-operator-utils v1.25.10 h1:UITYPaTX95SQTlUsrvQ+EUMeaDeymTbOTuzB7ihivl4=
@@ -11,6 +13,8 @@ github.com/Shopify/sarama v1.27.1 h1:iUlzHymqWsITyttu6KxazcAz8WEj5FqcwFK/oEi7rE8
 github.com/Shopify/sarama v1.27.1/go.mod h1:g5s5osgELxgM+Md9Qni9rzo7Rbt+vvFQI4bt/Mc93II=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/Unleash/unleash-client-go/v4 v4.1.3 h1:e0wtNAhvpdH4GAHxJ5nmq6GA2uR49cAwlWTNMfJSl9I=
+github.com/Unleash/unleash-client-go/v4 v4.1.3/go.mod h1:k7LRAXyKeZ1DwqGaKn1KZo92e9JVlEPut4CAhutPJmU=
 github.com/archdx/zerolog-sentry v1.8.4 h1:Thxb8Crm+JaV1kcAF2KEcpKwkMtQaj+GazhktFgGTUc=
 github.com/archdx/zerolog-sentry v1.8.4/go.mod h1:XrFHGe1CH5DQk/XSySu/IJSi5C9XR6+zpc97zVf/c4c=
 github.com/aws/aws-sdk-go v1.30.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -70,7 +74,9 @@ github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyE
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/h2non/gock v1.2.0/go.mod h1:tNhoxHYW2W42cYkYb1WqzdbYIieALC99kpYr7rH/BQk=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -108,6 +114,7 @@ github.com/mozillazg/request v0.8.0 h1:TbXeQUdBWr1J1df5Z+lQczDFzX9JD71kTCl7Zu/9r
 github.com/mozillazg/request v0.8.0/go.mod h1:weoQ/mVFNbWgRBtivCGF1tUT9lwneFesues+CleXMWc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
@@ -157,10 +164,12 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.19.0 h1:RWq5SEjt8o25SROyN3z2OrDB9l7RPd3lwTWU8EcEdcI=
 github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -173,6 +182,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tisnik/go-capture v1.0.1 h1:o4zZpOlC01qCifeh0fj4SoUkt8UHFassn1+blmFN3BQ=
 github.com/tisnik/go-capture v1.0.1/go.mod h1:NArgKXuvcG6gOW2SQoPGKy6TuiKBttQ2ZV0/zC4zVaY=
+github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
+github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/verdverm/frisby v0.0.0-20170604211311-b16556248a9a h1:Mt+KWT4h97wIDQahX1eD3OLkmc/fGbLy7EndiE85kMQ=
 github.com/verdverm/frisby v0.0.0-20170604211311-b16556248a9a/go.mod h1:Z+jvFzFlZ6eHAKMfi8PZZphUtg4S0gc2EZYOL9UnWgA=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type Configuration struct {
 	ServerConfig        server.Config                     `mapstructure:"server" toml:"server"`
 	AuthConfig          server.AuthConfig                 `mapstructure:"auth" toml:"auth"`
 	StorageConfig       service.StorageConfig             `mapstructure:"storage" toml:"storage"`
+	CanaryConfig        service.CanaryConfig              `mapstructure:"canary" toml:"canary"`
 	LoggingConfig       logger.LoggingConfiguration       `mapstructure:"logging" toml:"logging"`
 	CloudWatchConfig    logger.CloudWatchConfiguration    `mapstructure:"cloudwatch" toml:"cloudwatch"`
 	SentryLoggingConfig logger.SentryLoggingConfiguration `mapstructure:"sentry" toml:"sentry"`
@@ -130,6 +131,11 @@ func StorageConfig() service.StorageConfig {
 	return Config.StorageConfig
 }
 
+// CanaryConfig function returns actual canary configuration.
+func CanaryConfig() service.CanaryConfig {
+	return Config.CanaryConfig
+}
+
 // LoggingConfig function returns actual logger configuration.
 func LoggingConfig() logger.LoggingConfiguration {
 	return Config.LoggingConfig
@@ -161,7 +167,7 @@ func updateConfigFromClowder(configuration *Configuration) {
 	fmt.Println("Clowder is enabled")
 
 	if clowder.LoadedConfig.FeatureFlags != nil {
-		configuration.StorageConfig.UnleashToken = *clowder.LoadedConfig.FeatureFlags.ClientAccessToken
+		configuration.CanaryConfig.UnleashToken = *clowder.LoadedConfig.FeatureFlags.ClientAccessToken
 	} else {
 		fmt.Println(noFeatureFlags)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -51,6 +51,13 @@ var (
 			RemoteConfigurationPath: "remote_configurations",
 			ClusterMappingPath:      "./tests/rapid-recommendations/cluster-mapping.json",
 		},
+		CanaryConfig: service.CanaryConfig{
+			UnleashEnabled: false,
+			UnleashURL:     "https://unleash-url/api",
+			UnleashToken:   "",
+			UnleashApp:     "default",
+			UnleashToggle:  "insights-operator-gathering-conditions-service",
+		},
 		SentryLoggingConfig: logger.SentryLoggingConfiguration{
 			SentryDSN: "dsn",
 		},
@@ -188,6 +195,9 @@ func TestGetConfigFunctions(t *testing.T) {
 	t.Run("StorageConfig", func(t *testing.T) {
 		assert.Equal(t, config.Config.StorageConfig, config.StorageConfig())
 	})
+	t.Run("CanaryConfig", func(t *testing.T) {
+		assert.Equal(t, config.Config.CanaryConfig, config.CanaryConfig())
+	})
 	t.Run("LoggingConfig", func(t *testing.T) {
 		assert.Equal(t, config.Config.LoggingConfig, config.LoggingConfig())
 	})
@@ -223,6 +233,6 @@ func TestLoadConfigurationKafkaTopicUpdatedFromClowder(t *testing.T) {
 	err = config.LoadConfiguration("testdata/valid_config.toml")
 	assert.NoError(t, err, "Failed loading configuration file")
 
-	storageCfg := config.StorageConfig()
-	assert.Equal(t, unleashToken, storageCfg.UnleashToken)
+	canaryCfg := config.CanaryConfig()
+	assert.Equal(t, unleashToken, canaryCfg.UnleashToken)
 }

--- a/internal/config/testdata/valid-config.toml
+++ b/internal/config/testdata/valid-config.toml
@@ -12,6 +12,13 @@ rules_path = "rules_path"
 remote_configuration = "remote_configurations"
 cluster_mapping = "./tests/rapid-recommendations/cluster-mapping.json"
 
+[canary]
+unleash_enabled = false
+unleash_url = "https://unleash-url/api"
+unleash_token = ""
+unleash_app = "default"
+unleash_toggle = "insights-operator-gathering-conditions-service"
+
 [sentry]
 dsn = "dsn"
 

--- a/internal/service/cluster_mapping_test.go
+++ b/internal/service/cluster_mapping_test.go
@@ -38,6 +38,29 @@ func TestClusterMappingIsValid(t *testing.T) {
 		}
 		assert.False(t, sut.IsValid(testFilesPath, service.StableVersion))
 	})
+
+	t.Run("invalid map: versions unsorted", func(t *testing.T) {
+		var sut service.ClusterMapping = [][]string{
+			{"1.0.0", "experimental_1.json"},
+			{"3.0.0", "experimental_2.json"},
+			{"2.0.0", "config_default.json"},
+		}
+		assert.False(t, sut.IsValid(testFilesPath, service.StableVersion))
+	})
+
+	t.Run("invalid map: map contains a tripple instead of key-values pairs", func(t *testing.T) {
+		var sut service.ClusterMapping = [][]string{
+			{"1.0.0", "experimental_1.json", "some-element"},
+			{"2.0.0", "experimental_2.json"},
+			{"3.0.0", "config_default.json"},
+		}
+		assert.False(t, sut.IsValid(testFilesPath, service.StableVersion))
+	})
+
+	t.Run("invalid map: map is empty", func(t *testing.T) {
+		var sut service.ClusterMapping = [][]string{}
+		assert.False(t, sut.IsValid(testFilesPath, service.StableVersion))
+	})
 }
 
 func TestClusterMappingGetFilepathForVersion(t *testing.T) {

--- a/internal/service/common_test.go
+++ b/internal/service/common_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Red Hat, Inc.
+Copyright © 2022, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package service_test
 import "github.com/RedHatInsights/insights-operator-gathering-conditions-service/internal/service"
 
 var (
-	validRules = service.Rules{
+	validStableRules = service.Rules{
 		Version: "0.0.1",
 		Items: []service.Rule{
 			{
@@ -31,7 +31,7 @@ var (
 			},
 		},
 	}
-	validRulesJSON = `
+	validStableRulesJSON = `
 	{
 		"version": "0.0.1",
 		"rules": [
@@ -42,7 +42,19 @@ var (
 		]
 	}
 	`
-	validRemoteConfiguration = service.RemoteConfiguration{
+	validCanaryRules = service.Rules{
+		Version: "0.0.2",
+		Items: []service.Rule{
+			{
+				Conditions: []interface{}{
+					"condition 2",
+					"condition 3",
+				},
+				GatheringFunctions: "the gathering functions",
+			},
+		},
+	}
+	validStableRemoteConfiguration = service.RemoteConfiguration{
 		Version: "0.0.1",
 		ConditionalRules: []service.Rule{
 			{
@@ -65,7 +77,7 @@ var (
 			},
 		},
 	}
-	validRemoteConfigurationJSON = `
+	validStableRemoteConfigurationJSON = `
 	{
 		"version": "0.0.1",
 		"conditional_gathering_rules": [
@@ -87,12 +99,38 @@ var (
 		]
 	}
 	`
+	validCanaryRemoteConfiguration = service.RemoteConfiguration{
+		Version: "0.0.2",
+		ConditionalRules: []service.Rule{
+			{
+				Conditions: []interface{}{
+					"condition 2",
+					"condition 3",
+				},
+				GatheringFunctions: "the gathering functions",
+			},
+		},
+		ContainerLogsRequests: []service.ContainerLogRequest{
+			{
+				Namespace:    "namespace-1",
+				Previous:     true,
+				PodNameRegex: "test regex",
+				Messages: []string{
+					"first message",
+					"second message",
+				},
+			},
+		},
+	}
 
 	configDefaultConfiguration = `{"conditional_gathering_rules":[{"conditions":[{"type":"alert_is_firing","alert":{"name":"AlertmanagerFailedReload"}}],"gathering_functions":{"containers_logs":{"alert_name":"AlertmanagerFailedReload","container":"alertmanager","tail_lines":50}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"AlertmanagerFailedToSendAlerts"}}],"gathering_functions":{"containers_logs":{"alert_name":"AlertmanagerFailedToSendAlerts","tail_lines":50,"container":"alertmanager"}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"APIRemovedInNextEUSReleaseInUse"}}],"gathering_functions":{"api_request_counts_of_resource_from_alert":{"alert_name":"APIRemovedInNextEUSReleaseInUse"}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"KubePodCrashLooping"}}],"gathering_functions":{"containers_logs":{"alert_name":"KubePodCrashLooping","tail_lines":20,"previous":true}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"KubePodNotReady"}}],"gathering_functions":{"containers_logs":{"alert_name":"KubePodNotReady","tail_lines":100},"pod_definition":{"alert_name":"KubePodNotReady"}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"PrometheusOperatorSyncFailed"}}],"gathering_functions":{"containers_logs":{"alert_name":"PrometheusOperatorSyncFailed","tail_lines":50,"container":"prometheus-operator"}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"PrometheusTargetSyncFailure"}}],"gathering_functions":{"containers_logs":{"alert_name":"PrometheusTargetSyncFailure","container":"prometheus","tail_lines":50}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"SamplesImagestreamImportFailing"}}],"gathering_functions":{"logs_of_namespace":{"namespace":"openshift-cluster-samples-operator","tail_lines":100},"image_streams_of_namespace":{"namespace":"openshift-cluster-samples-operator"}}},{"conditions":[{"type":"alert_is_firing","alert":{"name":"ThanosRuleQueueIsDroppingAlerts"}}],"gathering_functions":{"containers_logs":{"alert_name":"ThanosRuleQueueIsDroppingAlerts","container":"thanos-ruler","tail_lines":50}}}],"container_logs":[],"version":"1.1.0"}`
 	emptyConfiguration         = `{"conditional_gathering_rules":[],"container_logs":[],"version":"1.1.0"}`
 	experimental1Configuration = `{"conditional_gathering_rules":[{"conditions":[{"type":"alert_is_firing","alert":{"name":"Experimental1"}}],"gathering_functions":{"containers_logs":{"alert_name":"Experimental1","container":"experimental1","tail_lines":50}}}],"container_logs":[],"version":"1.1.0"}`
 	bugWorkaroundConfiguration = `{"conditional_gathering_rules":[{"conditions":[{"type":"alert_is_firing","alert":{"name":"BugWorkaround"}}],"gathering_functions":{"containers_logs":{"alert_name":"BugWorkaround","container":"bug-workaround","tail_lines":50}}}],"container_logs":[],"version":"1.1.0"}`
 	experimental2Configuration = `{"conditional_gathering_rules":[{"conditions":[{"type":"alert_is_firing","alert":{"name":"Experimental2"}}],"gathering_functions":{"containers_logs":{"alert_name":"Experimental2","container":"experimental2","tail_lines":50}}}],"container_logs":[],"version":"1.1.0"}`
+
+	clusterID              = "9abc1e7a-d834-4c6d-99b1-826399958d1c"
+	userAgentWithClusterID = "insights-operator/4.14.27-$Format:%H$ cluster/9abc1e7a-d834-4c6d-99b1-826399958d1c"
 )
 
 type mockStorage struct {
@@ -102,11 +140,11 @@ type mockStorage struct {
 	getRemoteConfigurationFilepathMockError error
 }
 
-func (m *mockStorage) ReadConditionalRules(string) []byte {
+func (m *mockStorage) ReadConditionalRules(string, string) []byte {
 	return m.conditionalRules
 }
 
-func (m *mockStorage) ReadRemoteConfig(string) []byte {
+func (m *mockStorage) ReadRemoteConfig(string, string) []byte {
 	return m.remoteConfig
 }
 

--- a/internal/service/common_test.go
+++ b/internal/service/common_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package service_test
 
-import "github.com/RedHatInsights/insights-operator-gathering-conditions-service/internal/service"
+import (
+	"net/http"
+
+	"github.com/RedHatInsights/insights-operator-gathering-conditions-service/internal/service"
+)
 
 var (
 	validStableRules = service.Rules{
@@ -129,8 +133,8 @@ var (
 	bugWorkaroundConfiguration = `{"conditional_gathering_rules":[{"conditions":[{"type":"alert_is_firing","alert":{"name":"BugWorkaround"}}],"gathering_functions":{"containers_logs":{"alert_name":"BugWorkaround","container":"bug-workaround","tail_lines":50}}}],"container_logs":[],"version":"1.1.0"}`
 	experimental2Configuration = `{"conditional_gathering_rules":[{"conditions":[{"type":"alert_is_firing","alert":{"name":"Experimental2"}}],"gathering_functions":{"containers_logs":{"alert_name":"Experimental2","container":"experimental2","tail_lines":50}}}],"container_logs":[],"version":"1.1.0"}`
 
-	clusterID              = "9abc1e7a-d834-4c6d-99b1-826399958d1c"
-	userAgentWithClusterID = "insights-operator/4.14.27-$Format:%H$ cluster/9abc1e7a-d834-4c6d-99b1-826399958d1c"
+	stableUserAgent = "insights-operator/4.14.27-$Format:%H$ cluster/9abc1e7a-d834-4c6d-99b1-826399958d1c"
+	canaryUserAgent = "insights-operator/4.14.27-$Format:%H$ cluster/f9fbc65a-52e6-4781-979d-1d5c6b124f9b"
 )
 
 type mockStorage struct {
@@ -140,11 +144,11 @@ type mockStorage struct {
 	getRemoteConfigurationFilepathMockError error
 }
 
-func (m *mockStorage) ReadConditionalRules(string, string) []byte {
+func (m *mockStorage) ReadConditionalRules(*http.Request, string) []byte {
 	return m.conditionalRules
 }
 
-func (m *mockStorage) ReadRemoteConfig(string, string) []byte {
+func (m *mockStorage) ReadRemoteConfig(*http.Request, string) []byte {
 	return m.remoteConfig
 }
 

--- a/internal/service/endpoints_test.go
+++ b/internal/service/endpoints_test.go
@@ -125,6 +125,19 @@ func (l *logSink) Index(i int) string {
 	return l.logs[i]
 }
 
+func TestGetClusterID(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	assert.NoError(t, err)
+
+	req.Header.Add("Authorization", "Bearer token")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", userAgentWithClusterID)
+
+	clusterID, err := service.GetClusterID(req)
+	assert.NoError(t, err)
+	assert.Equal(t, clusterID, "9abc1e7a-d834-4c6d-99b1-826399958d1c")
+}
+
 func TestGetClusterIDHeaderWithoutClusterID(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	assert.NoError(t, err)

--- a/internal/service/endpoints_test.go
+++ b/internal/service/endpoints_test.go
@@ -124,29 +124,3 @@ func (l *logSink) Write(p []byte) (n int, err error) {
 func (l *logSink) Index(i int) string {
 	return l.logs[i]
 }
-
-func TestGetClusterID(t *testing.T) {
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	assert.NoError(t, err)
-
-	req.Header.Add("Authorization", "Bearer token")
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", userAgentWithClusterID)
-
-	clusterID, err := service.GetClusterID(req)
-	assert.NoError(t, err)
-	assert.Equal(t, clusterID, "9abc1e7a-d834-4c6d-99b1-826399958d1c")
-}
-
-func TestGetClusterIDHeaderWithoutClusterID(t *testing.T) {
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	assert.NoError(t, err)
-
-	req.Header.Add("Authorization", "Bearer token")
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", "Go-http-client/1.1")
-
-	clusterID, err := service.GetClusterID(req)
-	assert.Equal(t, clusterID, "")
-	assert.NotNil(t, err)
-}

--- a/internal/service/endpoints_test.go
+++ b/internal/service/endpoints_test.go
@@ -124,3 +124,16 @@ func (l *logSink) Write(p []byte) (n int, err error) {
 func (l *logSink) Index(i int) string {
 	return l.logs[i]
 }
+
+func TestGetClusterIDHeaderWithoutClusterID(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	assert.NoError(t, err)
+
+	req.Header.Add("Authorization", "Bearer token")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "Go-http-client/1.1")
+
+	clusterID, err := service.GetClusterID(req)
+	assert.Equal(t, clusterID, "")
+	assert.NotNil(t, err)
+}

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -28,4 +28,5 @@ package service
 var (
 	RenderResponse = renderResponse
 	LogHeaders     = logHeaders
+	GetClusterID   = getClusterID
 )

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -28,5 +28,4 @@ package service
 var (
 	RenderResponse = renderResponse
 	LogHeaders     = logHeaders
-	GetClusterID   = getClusterID
 )

--- a/internal/service/handler_test.go
+++ b/internal/service/handler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Red Hat, Inc.
+Copyright © 2022, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ func TestWrongMethods(t *testing.T) {
 	methods := []string{"POST", "PUT", "DELETE"}
 
 	store := mockStorage{
-		conditionalRules: []byte(validRemoteConfigurationJSON),
+		conditionalRules: []byte(validStableRemoteConfigurationJSON),
 	}
 	repo := service.NewRepository(&store)
 	svc := service.New(repo)

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021, 2022 Red Hat, Inc.
+Copyright © 2021, 2022, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import (
 
 // RepositoryInterface defines methods to be implemented by any rules providers
 type RepositoryInterface interface {
-	Rules() (*Rules, error)
-	RemoteConfiguration(ocpVersion string) (*RemoteConfiguration, error)
+	Rules(clusterID string) (*Rules, error)
+	RemoteConfiguration(ocpVersion string, clusterID string) (*RemoteConfiguration, error)
 }
 
 // Rule data type definition based on original JSON schema
@@ -67,9 +67,9 @@ func NewRepository(s StorageInterface) *Repository {
 }
 
 // Rules method reads all and unmarshals all rules stored under given path
-func (r *Repository) Rules() (*Rules, error) {
+func (r *Repository) Rules(clusterID string) (*Rules, error) {
 	filepath := "rules.json" // TODO: Make this configurable
-	data := r.store.ReadConditionalRules(filepath)
+	data := r.store.ReadConditionalRules(filepath, clusterID)
 	if data == nil {
 		return nil, fmt.Errorf("store data not found for '%s'", filepath)
 	}
@@ -85,12 +85,12 @@ func (r *Repository) Rules() (*Rules, error) {
 
 // RemoteConfiguration returns a remote configuration for v2 endpoint based on
 // the cluster map defined in the settings and loaded on startup
-func (r *Repository) RemoteConfiguration(ocpVersion string) (*RemoteConfiguration, error) {
+func (r *Repository) RemoteConfiguration(ocpVersion string, clusterID string) (*RemoteConfiguration, error) {
 	filepath, err := r.store.GetRemoteConfigurationFilepath(ocpVersion)
 	if err != nil {
 		return nil, err
 	}
-	data := r.store.ReadRemoteConfig(filepath)
+	data := r.store.ReadRemoteConfig(filepath, clusterID)
 	if data == nil {
 		return nil, fmt.Errorf("store data not found for '%s'", filepath)
 	}

--- a/internal/service/repository_test.go
+++ b/internal/service/repository_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service_test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/RedHatInsights/insights-operator-gathering-conditions-service/internal/service"
@@ -55,7 +56,7 @@ func TestRepositoryRules(t *testing.T) {
 				conditionalRules: tc.mockConditionalRules,
 			}
 			r := service.NewRepository(&m)
-			rules, err := r.Rules(clusterID)
+			rules, err := r.Rules(&http.Request{})
 			if tc.expectedAnError {
 				assert.Error(t, err)
 			} else {
@@ -99,7 +100,7 @@ func TestRepositoryRemoteConfiguration(t *testing.T) {
 				remoteConfig: tt.mockRemoteConfig,
 			}
 			r := service.NewRepository(&m)
-			remoteConfig, err := r.RemoteConfiguration(anyVer, clusterID)
+			remoteConfig, err := r.RemoteConfiguration(&http.Request{}, anyVer)
 			if tt.expectedAnError {
 				assert.Error(t, err)
 			} else {

--- a/internal/service/repository_test.go
+++ b/internal/service/repository_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Red Hat, Inc.
+Copyright © 2022, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -44,9 +44,9 @@ func TestRepositoryRules(t *testing.T) {
 		},
 		{
 			name:                 "valid rules returned by storage",
-			mockConditionalRules: []byte(validRulesJSON),
+			mockConditionalRules: []byte(validStableRulesJSON),
 			expectedAnError:      false,
-			expectedRules:        validRules,
+			expectedRules:        validStableRules,
 		},
 	}
 	for _, tc := range testCases {
@@ -55,7 +55,7 @@ func TestRepositoryRules(t *testing.T) {
 				conditionalRules: tc.mockConditionalRules,
 			}
 			r := service.NewRepository(&m)
-			rules, err := r.Rules()
+			rules, err := r.Rules(clusterID)
 			if tc.expectedAnError {
 				assert.Error(t, err)
 			} else {
@@ -87,9 +87,9 @@ func TestRepositoryRemoteConfiguration(t *testing.T) {
 		},
 		{
 			name:                 "valid remote configuration returned by storage",
-			mockRemoteConfig:     []byte(validRemoteConfigurationJSON),
+			mockRemoteConfig:     []byte(validStableRemoteConfigurationJSON),
 			expectedAnError:      false,
-			expectedRemoteConfig: validRemoteConfiguration,
+			expectedRemoteConfig: validStableRemoteConfiguration,
 		},
 	}
 
@@ -99,7 +99,7 @@ func TestRepositoryRemoteConfiguration(t *testing.T) {
 				remoteConfig: tt.mockRemoteConfig,
 			}
 			r := service.NewRepository(&m)
-			remoteConfig, err := r.RemoteConfiguration(anyVer)
+			remoteConfig, err := r.RemoteConfiguration(anyVer, clusterID)
 			if tt.expectedAnError {
 				assert.Error(t, err)
 			} else {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021, 2022 Red Hat, Inc.
+Copyright © 2021, 2022, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package service
 
 // RulesProvider defines methods to be implemented by any rules provider
 type RulesProvider interface {
-	Rules() (*Rules, error)
-	RemoteConfiguration(ocpVersion string) (*RemoteConfiguration, error)
+	Rules(clusterID string) (*Rules, error)
+	RemoteConfiguration(ocpVersion string, clusterID string) (*RemoteConfiguration, error)
 }
 
 // Service data type represents the whole service for repository interface.
@@ -35,8 +35,8 @@ func New(repo RepositoryInterface) *Service {
 }
 
 // Rules method returns all rules provided by the service.
-func (s *Service) Rules() (*Rules, error) {
-	rules, err := s.repo.Rules()
+func (s *Service) Rules(clusterID string) (*Rules, error) {
+	rules, err := s.repo.Rules(clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +45,8 @@ func (s *Service) Rules() (*Rules, error) {
 }
 
 // RemoteConfiguration method returns the remote configuration provided by the service.
-func (s *Service) RemoteConfiguration(ocpVersion string) (*RemoteConfiguration, error) {
-	remoteConfiguration, err := s.repo.RemoteConfiguration(ocpVersion)
+func (s *Service) RemoteConfiguration(ocpVersion string, clusterID string) (*RemoteConfiguration, error) {
+	remoteConfiguration, err := s.repo.RemoteConfiguration(ocpVersion, clusterID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -16,10 +16,12 @@ limitations under the License.
 
 package service
 
+import "net/http"
+
 // RulesProvider defines methods to be implemented by any rules provider
 type RulesProvider interface {
-	Rules(clusterID string) (*Rules, error)
-	RemoteConfiguration(ocpVersion string, clusterID string) (*RemoteConfiguration, error)
+	Rules(r *http.Request) (*Rules, error)
+	RemoteConfiguration(r *http.Request, ocpVersion string) (*RemoteConfiguration, error)
 }
 
 // Service data type represents the whole service for repository interface.
@@ -35,8 +37,8 @@ func New(repo RepositoryInterface) *Service {
 }
 
 // Rules method returns all rules provided by the service.
-func (s *Service) Rules(clusterID string) (*Rules, error) {
-	rules, err := s.repo.Rules(clusterID)
+func (s *Service) Rules(r *http.Request) (*Rules, error) {
+	rules, err := s.repo.Rules(r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +47,8 @@ func (s *Service) Rules(clusterID string) (*Rules, error) {
 }
 
 // RemoteConfiguration method returns the remote configuration provided by the service.
-func (s *Service) RemoteConfiguration(ocpVersion string, clusterID string) (*RemoteConfiguration, error) {
-	remoteConfiguration, err := s.repo.RemoteConfiguration(ocpVersion, clusterID)
+func (s *Service) RemoteConfiguration(r *http.Request, ocpVersion string) (*RemoteConfiguration, error) {
+	remoteConfiguration, err := s.repo.RemoteConfiguration(r, ocpVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -68,7 +68,7 @@ func TestServiceV1(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				req.Header.Set("User-Agent", userAgentWithClusterID)
+				req.Header.Set("User-Agent", stableUserAgent)
 
 				rr := httptest.NewRecorder() // Used to record the response.
 				handler := service.NewHandler(svc)
@@ -128,7 +128,7 @@ func TestServiceV2(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			req.Header.Set("User-Agent", userAgentWithClusterID)
+			req.Header.Set("User-Agent", stableUserAgent)
 
 			rr := httptest.NewRecorder() // Used to record the response.
 			handler := service.NewHandler(svc)
@@ -302,7 +302,7 @@ func TestServiceV2WithClusterMapping(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			req.Header.Set("User-Agent", userAgentWithClusterID)
+			req.Header.Set("User-Agent", stableUserAgent)
 
 			rr := httptest.NewRecorder()
 			handler := service.NewHandler(svc)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Red Hat, Inc.
+Copyright © 2022, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ func TestServiceV1(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:            "valid rule stored",
-			mockData:        []byte(validRulesJSON),
+			mockData:        []byte(validStableRulesJSON),
 			expectedAnError: false,
 		},
 		{
@@ -67,6 +67,8 @@ func TestServiceV1(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+
+				req.Header.Set("User-Agent", userAgentWithClusterID)
 
 				rr := httptest.NewRecorder() // Used to record the response.
 				handler := service.NewHandler(svc)
@@ -102,7 +104,7 @@ func TestServiceV2(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:            "valid remote configuration stored",
-			mockData:        []byte(validRemoteConfigurationJSON),
+			mockData:        []byte(validStableRemoteConfigurationJSON),
 			expectedAnError: false,
 		},
 		{
@@ -125,6 +127,8 @@ func TestServiceV2(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			req.Header.Set("User-Agent", userAgentWithClusterID)
 
 			rr := httptest.NewRecorder() // Used to record the response.
 			handler := service.NewHandler(svc)
@@ -282,7 +286,7 @@ func TestServiceV2WithClusterMapping(t *testing.T) {
 				RulesPath:               "../../tests/conditions",
 				RemoteConfigurationPath: "../../tests/rapid-recommendations",
 				ClusterMappingPath:      tc.clusterMappingFilepath,
-			})
+			}, &MockUnleashClient{})
 			if tc.expectedAnError {
 				assert.Error(t, err, "this configuration should have made the service crash")
 				return
@@ -297,6 +301,8 @@ func TestServiceV2WithClusterMapping(t *testing.T) {
 				tc.ocpVersion), http.NoBody)
 
 			assert.NoError(t, err)
+
+			req.Header.Set("User-Agent", userAgentWithClusterID)
 
 			rr := httptest.NewRecorder()
 			handler := service.NewHandler(svc)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -286,7 +286,7 @@ func TestServiceV2WithClusterMapping(t *testing.T) {
 				RulesPath:               "../../tests/conditions",
 				RemoteConfigurationPath: "../../tests/rapid-recommendations",
 				ClusterMappingPath:      tc.clusterMappingFilepath,
-			}, &MockUnleashClient{})
+			}, true, &MockUnleashClient{})
 			if tc.expectedAnError {
 				assert.Error(t, err, "this configuration should have made the service crash")
 				return

--- a/internal/service/storage.go
+++ b/internal/service/storage.go
@@ -177,10 +177,10 @@ func (s *Storage) ReadConditionalRules(path string, clusterID string) []byte {
 	version := StableVersion
 	if s.unleashEnabled {
 		if s.unleashClient.IsCanary(clusterID) {
-			log.Info().Str("cluster", clusterID).Msg("Served canary version of rules")
+			log.Debug().Str("cluster", clusterID).Msg("Served canary version of rules")
 			version = CanaryVersion
 		} else {
-			log.Info().Str("cluster", clusterID).Msg("Served stable version of rules")
+			log.Debug().Str("cluster", clusterID).Msg("Served stable version of rules")
 		}
 	}
 	conditionalRulesPath := fmt.Sprintf("%s/%s/%s", s.conditionalRulesPath, version, path)
@@ -193,10 +193,10 @@ func (s *Storage) ReadRemoteConfig(path string, clusterID string) []byte {
 	version := StableVersion
 	if s.unleashEnabled {
 		if s.unleashClient.IsCanary(clusterID) {
-			log.Info().Str("cluster", clusterID).Msg("Served canary version of remote configurations")
+			log.Debug().Str("cluster", clusterID).Msg("Served canary version of remote configurations")
 			version = CanaryVersion
 		} else {
-			log.Info().Str("cluster", clusterID).Msg("Served stable version of remote configurations")
+			log.Debug().Str("cluster", clusterID).Msg("Served stable version of remote configurations")
 		}
 	}
 	remoteConfigPath := fmt.Sprintf("%s/%s/%s", s.remoteConfigurationPath, version, path)

--- a/internal/service/storage.go
+++ b/internal/service/storage.go
@@ -59,11 +59,15 @@ type StorageConfig struct {
 	RulesPath               string `mapstructure:"rules_path" toml:"rules_path"`
 	RemoteConfigurationPath string `mapstructure:"remote_configuration" toml:"remote_configuration"`
 	ClusterMappingPath      string `mapstructure:"cluster_mapping" toml:"cluster_mapping"`
-	UnleashURL              string `mapstructure:"unleash_url" toml:"unleash_url"`
-	UnleashToken            string `mapstructure:"unleash_token" toml:"unleash_token"`
-	UnleashApp              string `mapstructure:"unleash_app" toml:"unleash_app"`
-	UnleashToggle           string `mapstructure:"unleash_toggle" toml:"unleash_toggle"`
-	UnleashEnabled          bool   `mapstructure:"unleash_enabled" toml:"unleash_enabled"`
+}
+
+// CanaryConfig structure contains configuration for canary rollout
+type CanaryConfig struct {
+	UnleashURL     string `mapstructure:"unleash_url" toml:"unleash_url"`
+	UnleashToken   string `mapstructure:"unleash_token" toml:"unleash_token"`
+	UnleashApp     string `mapstructure:"unleash_app" toml:"unleash_app"`
+	UnleashToggle  string `mapstructure:"unleash_toggle" toml:"unleash_toggle"`
+	UnleashEnabled bool   `mapstructure:"unleash_enabled" toml:"unleash_enabled"`
 }
 
 // Cache type represents thread safe map for storing loaded configurations
@@ -91,7 +95,7 @@ type UnleashClient struct {
 }
 
 // NewUnleashClient constructs new Unleash client along with Unleash initialization
-func NewUnleashClient(cfg StorageConfig) (*UnleashClient, error) {
+func NewUnleashClient(cfg CanaryConfig) (*UnleashClient, error) {
 	c := UnleashClient{unleashToggle: cfg.UnleashToggle}
 	log.Info().Msg("Initializing Unleash")
 	err := unleash.Initialize(
@@ -124,13 +128,13 @@ type Storage struct {
 }
 
 // NewStorage constructs new storage object.
-func NewStorage(cfg StorageConfig, unleashClient UnleashClientInterface) (*Storage, error) {
-	log.Debug().Interface("config", cfg).Msg("Constructing storage object")
+func NewStorage(storageConfig StorageConfig, unleashEnabled bool, unleashClient UnleashClientInterface) (*Storage, error) {
+	log.Debug().Interface("config", storageConfig).Msg("Constructing storage object")
 	s := Storage{
-		conditionalRulesPath:    cfg.RulesPath,
-		remoteConfigurationPath: cfg.RemoteConfigurationPath,
-		clusterMappingPath:      cfg.ClusterMappingPath,
-		unleashEnabled:          cfg.UnleashEnabled,
+		conditionalRulesPath:    storageConfig.RulesPath,
+		remoteConfigurationPath: storageConfig.RemoteConfigurationPath,
+		clusterMappingPath:      storageConfig.ClusterMappingPath,
+		unleashEnabled:          unleashEnabled,
 		unleashClient:           unleashClient,
 	}
 

--- a/internal/service/storage_test.go
+++ b/internal/service/storage_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Red Hat, Inc.
+Copyright © 2022, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,67 @@ const (
 	rulesFolder            = "testdata/v1"
 	v2Folder               = "testdata/v2"
 	clusterMappingFilepath = "testdata/cluster-mapping.json"
+	stableClusterID        = "27badff1-9f61-4168-a309-6878a66075b3"
+	canaryClusterID        = "f9fbc65a-52e6-4781-979d-1d5c6b124f9b"
 )
+
+type MockUnleashClient struct{}
+
+func (c *MockUnleashClient) IsCanary(clusterID string) bool {
+	return clusterID == canaryClusterID
+}
+
+func TestNewStorage(t *testing.T) {
+	type testCase struct {
+		name        string
+		config      service.StorageConfig
+		expectError bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "config is valid",
+			config: service.StorageConfig{
+				RulesPath:               "testdata/v1",
+				RemoteConfigurationPath: "testdata/v2",
+				ClusterMappingPath:      "testdata/cluster-mapping.json",
+				UnleashEnabled:          false,
+			},
+			expectError: false,
+		},
+		{
+			name: "config is invalid: stable version of data does not exit",
+			config: service.StorageConfig{
+				RulesPath:               "testdata/v1",
+				RemoteConfigurationPath: "testdata/v2_missing_stable",
+				ClusterMappingPath:      "testdata/cluster-mapping.json",
+				UnleashEnabled:          false,
+			},
+			expectError: true,
+		},
+		{
+			name: "config is invalid: canary version of data does not exit",
+			config: service.StorageConfig{
+				RulesPath:               "testdata/v1",
+				RemoteConfigurationPath: "testdata/v2_missing_canary",
+				ClusterMappingPath:      "testdata/cluster-mapping.json",
+				UnleashEnabled:          false,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := service.NewStorage(tc.config, nil)
+			if tc.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestReadConditionalRules(t *testing.T) {
 	type testCase struct {
@@ -52,7 +112,7 @@ func TestReadConditionalRules(t *testing.T) {
 		{
 			name:          "file exists and is valid",
 			rulesFile:     validRulesFile,
-			expectedRules: validRules,
+			expectedRules: validStableRules,
 		},
 		{
 			name:          "reading from 'directory' instead of file",
@@ -68,9 +128,9 @@ func TestReadConditionalRules(t *testing.T) {
 					RulesPath:               rulesFolder,
 					ClusterMappingPath:      clusterMappingFilepath,
 					RemoteConfigurationPath: v2Folder,
-				})
+				}, nil)
 			assert.NoError(t, err)
-			checkConditionalRules(t, storage, tc.rulesFile, tc.expectedRules)
+			checkConditionalRules(t, storage, tc.rulesFile, tc.expectedRules, stableClusterID)
 		})
 	}
 
@@ -81,17 +141,52 @@ func TestReadConditionalRules(t *testing.T) {
 				RulesPath:               rulesFolder,
 				ClusterMappingPath:      clusterMappingFilepath,
 				RemoteConfigurationPath: v2Folder,
-			})
+			}, nil)
 		assert.NoError(t, err)
 		for i := 0; i < 2; i++ {
-			checkConditionalRules(t, storage, validRulesFile, validRules)
+			checkConditionalRules(t, storage, validRulesFile, validStableRules, stableClusterID)
 		}
 	})
 }
 
-func checkConditionalRules(t *testing.T, storage *service.Storage, rulesFile string, expectedRules service.Rules) {
+func TestReadRulesCanaryRollout(t *testing.T) {
+	tests := []struct {
+		name             string
+		clusterID        string
+		remoteConfigFile string
+		expectedRules    service.Rules
+	}{
+		{
+			name:             "cluster is served with stable version of rules",
+			clusterID:        stableClusterID,
+			remoteConfigFile: validRulesFile,
+			expectedRules:    validStableRules,
+		},
+		{
+			name:             "cluster is served with canary version of rules",
+			clusterID:        canaryClusterID,
+			remoteConfigFile: validRulesFile,
+			expectedRules:    validCanaryRules,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage, err := service.NewStorage(
+				service.StorageConfig{
+					RulesPath:               rulesFolder,
+					ClusterMappingPath:      clusterMappingFilepath,
+					RemoteConfigurationPath: v2Folder,
+					UnleashEnabled:          true,
+				}, &MockUnleashClient{})
+			assert.NoError(t, err)
+			checkConditionalRules(t, storage, tt.remoteConfigFile, tt.expectedRules, tt.clusterID)
+		})
+	}
+}
+
+func checkConditionalRules(t *testing.T, storage *service.Storage, rulesFile string, expectedRules service.Rules, clusterID string) {
 	var rules service.Rules
-	data := storage.ReadConditionalRules(rulesFile)
+	data := storage.ReadConditionalRules(rulesFile, clusterID)
 	if len(data) == 0 {
 		rules = service.Rules{}
 	} else {
@@ -101,9 +196,9 @@ func checkConditionalRules(t *testing.T, storage *service.Storage, rulesFile str
 	assert.Equal(t, expectedRules, rules)
 }
 
-func checkRemoteConfig(t *testing.T, storage *service.Storage, remoteConfigFile string, expectedRemoteConfig service.RemoteConfiguration) {
+func checkRemoteConfig(t *testing.T, storage *service.Storage, remoteConfigFile string, expectedRemoteConfig service.RemoteConfiguration, clusterID string) {
 	var remoteConfig service.RemoteConfiguration
-	data := storage.ReadRemoteConfig(remoteConfigFile)
+	data := storage.ReadRemoteConfig(remoteConfigFile, clusterID)
 	if len(data) == 0 {
 		remoteConfig = service.RemoteConfiguration{}
 	} else {
@@ -132,7 +227,7 @@ func TestReadRemoteConfiguration(t *testing.T) {
 		{
 			name:                 "file exists and is valid",
 			remoteConfigFile:     validRulesFile,
-			expectedRemoteConfig: validRemoteConfiguration,
+			expectedRemoteConfig: validStableRemoteConfiguration,
 		},
 		{
 			name:                 "reading from 'directory' instead of file",
@@ -147,9 +242,43 @@ func TestReadRemoteConfiguration(t *testing.T) {
 				service.StorageConfig{
 					RemoteConfigurationPath: v2Folder,
 					ClusterMappingPath:      clusterMappingFilepath,
-				})
+				}, nil)
 			assert.NoError(t, err)
-			checkRemoteConfig(t, storage, tt.remoteConfigFile, tt.expectedRemoteConfig)
+			checkRemoteConfig(t, storage, tt.remoteConfigFile, tt.expectedRemoteConfig, stableClusterID)
+		})
+	}
+}
+
+func TestReadRemoteConfigurationCanaryRollout(t *testing.T) {
+	tests := []struct {
+		name                 string
+		clusterID            string
+		remoteConfigFile     string
+		expectedRemoteConfig service.RemoteConfiguration
+	}{
+		{
+			name:                 "cluster is served with stable version of remote config",
+			clusterID:            stableClusterID,
+			remoteConfigFile:     validRulesFile,
+			expectedRemoteConfig: validStableRemoteConfiguration,
+		},
+		{
+			name:                 "cluster is served with canary version of remote config",
+			clusterID:            canaryClusterID,
+			remoteConfigFile:     validRulesFile,
+			expectedRemoteConfig: validCanaryRemoteConfiguration,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage, err := service.NewStorage(
+				service.StorageConfig{
+					RemoteConfigurationPath: v2Folder,
+					ClusterMappingPath:      clusterMappingFilepath,
+					UnleashEnabled:          true,
+				}, &MockUnleashClient{})
+			assert.NoError(t, err)
+			checkRemoteConfig(t, storage, tt.remoteConfigFile, tt.expectedRemoteConfig, tt.clusterID)
 		})
 	}
 }

--- a/internal/service/storage_test.go
+++ b/internal/service/storage_test.go
@@ -53,7 +53,6 @@ func TestNewStorage(t *testing.T) {
 				RulesPath:               "testdata/v1",
 				RemoteConfigurationPath: "testdata/v2",
 				ClusterMappingPath:      "testdata/cluster-mapping.json",
-				UnleashEnabled:          false,
 			},
 			expectError: false,
 		},
@@ -63,7 +62,6 @@ func TestNewStorage(t *testing.T) {
 				RulesPath:               "testdata/v1",
 				RemoteConfigurationPath: "testdata/v2_missing_stable",
 				ClusterMappingPath:      "testdata/cluster-mapping.json",
-				UnleashEnabled:          false,
 			},
 			expectError: true,
 		},
@@ -73,7 +71,6 @@ func TestNewStorage(t *testing.T) {
 				RulesPath:               "testdata/v1",
 				RemoteConfigurationPath: "testdata/v2_missing_canary",
 				ClusterMappingPath:      "testdata/cluster-mapping.json",
-				UnleashEnabled:          false,
 			},
 			expectError: true,
 		},
@@ -81,7 +78,7 @@ func TestNewStorage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := service.NewStorage(tc.config, nil)
+			_, err := service.NewStorage(tc.config, false, nil)
 			if tc.expectError {
 				assert.NotNil(t, err)
 			} else {
@@ -128,7 +125,7 @@ func TestReadConditionalRules(t *testing.T) {
 					RulesPath:               rulesFolder,
 					ClusterMappingPath:      clusterMappingFilepath,
 					RemoteConfigurationPath: v2Folder,
-				}, nil)
+				}, false, nil)
 			assert.NoError(t, err)
 			checkConditionalRules(t, storage, tc.rulesFile, tc.expectedRules, stableClusterID)
 		})
@@ -141,7 +138,7 @@ func TestReadConditionalRules(t *testing.T) {
 				RulesPath:               rulesFolder,
 				ClusterMappingPath:      clusterMappingFilepath,
 				RemoteConfigurationPath: v2Folder,
-			}, nil)
+			}, false, nil)
 		assert.NoError(t, err)
 		for i := 0; i < 2; i++ {
 			checkConditionalRules(t, storage, validRulesFile, validStableRules, stableClusterID)
@@ -176,8 +173,7 @@ func TestReadRulesCanaryRollout(t *testing.T) {
 					RulesPath:               rulesFolder,
 					ClusterMappingPath:      clusterMappingFilepath,
 					RemoteConfigurationPath: v2Folder,
-					UnleashEnabled:          true,
-				}, &MockUnleashClient{})
+				}, true, &MockUnleashClient{})
 			assert.NoError(t, err)
 			checkConditionalRules(t, storage, tt.remoteConfigFile, tt.expectedRules, tt.clusterID)
 		})
@@ -242,7 +238,7 @@ func TestReadRemoteConfiguration(t *testing.T) {
 				service.StorageConfig{
 					RemoteConfigurationPath: v2Folder,
 					ClusterMappingPath:      clusterMappingFilepath,
-				}, nil)
+				}, false, nil)
 			assert.NoError(t, err)
 			checkRemoteConfig(t, storage, tt.remoteConfigFile, tt.expectedRemoteConfig, stableClusterID)
 		})
@@ -275,8 +271,7 @@ func TestReadRemoteConfigurationCanaryRollout(t *testing.T) {
 				service.StorageConfig{
 					RemoteConfigurationPath: v2Folder,
 					ClusterMappingPath:      clusterMappingFilepath,
-					UnleashEnabled:          true,
-				}, &MockUnleashClient{})
+				}, true, &MockUnleashClient{})
 			assert.NoError(t, err)
 			checkRemoteConfig(t, storage, tt.remoteConfigFile, tt.expectedRemoteConfig, tt.clusterID)
 		})

--- a/internal/service/testdata/v1/canary/rules.json
+++ b/internal/service/testdata/v1/canary/rules.json
@@ -1,0 +1,12 @@
+{
+    "version":"0.0.2",
+    "rules": [
+        {
+            "conditions": [
+                "condition 2",
+                "condition 3"
+            ],
+            "gathering_functions": "the gathering functions"
+        }
+    ]
+}

--- a/internal/service/testdata/v2/canary/rules.json
+++ b/internal/service/testdata/v2/canary/rules.json
@@ -1,0 +1,23 @@
+{
+    "version":"0.0.2",
+    "conditional_gathering_rules": [
+        {
+            "conditions": [
+                "condition 2",
+                "condition 3"
+            ],
+            "gathering_functions": "the gathering functions"
+        }
+    ],
+    "container_logs": [
+        {
+            "namespace": "namespace-1",
+            "pod_name_regex": "test regex",
+            "previous": true,
+            "messages": [
+                "first message",
+		        "second message"
+            ]
+        }
+    ]
+}

--- a/internal/service/testdata/v2_missing_canary/stable/rules.json
+++ b/internal/service/testdata/v2_missing_canary/stable/rules.json
@@ -1,0 +1,23 @@
+{
+    "version":"0.0.1",
+    "conditional_gathering_rules": [
+        {
+            "conditions": [
+                "condition 1",
+                "condition 2"
+            ],
+            "gathering_functions": "the gathering functions"
+        }
+    ],
+    "container_logs": [
+        {
+            "namespace": "namespace-1",
+            "pod_name_regex": "test regex",
+            "previous": true,
+            "messages": [
+                "first message",
+		        "second message"
+            ]
+        }
+    ]
+}

--- a/internal/service/testdata/v2_missing_stable/canary/rules.json
+++ b/internal/service/testdata/v2_missing_stable/canary/rules.json
@@ -1,0 +1,23 @@
+{
+    "version":"0.0.1",
+    "conditional_gathering_rules": [
+        {
+            "conditions": [
+                "condition 1",
+                "condition 2"
+            ],
+            "gathering_functions": "the gathering functions"
+        }
+    ],
+    "container_logs": [
+        {
+            "namespace": "namespace-1",
+            "pod_name_regex": "test regex",
+            "previous": true,
+            "messages": [
+                "first message",
+		        "second message"
+            ]
+        }
+    ]
+}

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021, 2022, 2023 Red Hat, Inc.
+Copyright © 2021, 2022, 2023, 2024 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -101,7 +101,15 @@ func InitService() (*service.Service, error) {
 		logStorageError(err, storageConfig.RulesPath)
 		return nil, err
 	}
-	store, err := service.NewStorage(storageConfig)
+	var unleashClient *service.UnleashClient
+	if storageConfig.UnleashEnabled {
+		unleashClient, err = service.NewUnleashClient(storageConfig)
+		if err != nil {
+			log.Error().Err(err).Msg("Unleash could not be initialized")
+			return nil, err
+		}
+	}
+	store, err := service.NewStorage(storageConfig, unleashClient)
 	if err != nil {
 		log.Error().Err(err).Msg("Error initializing the storage")
 		return nil, err
@@ -122,6 +130,7 @@ func RunServer() error {
 
 	svc, err := InitService()
 	if err != nil {
+		log.Error().Err(err).Msg("Error occurred during service initialization")
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -102,14 +102,15 @@ func InitService() (*service.Service, error) {
 		return nil, err
 	}
 	var unleashClient *service.UnleashClient
-	if storageConfig.UnleashEnabled {
-		unleashClient, err = service.NewUnleashClient(storageConfig)
+	canaryConfig := config.CanaryConfig()
+	if canaryConfig.UnleashEnabled {
+		unleashClient, err = service.NewUnleashClient(canaryConfig)
 		if err != nil {
 			log.Error().Err(err).Msg("Unleash could not be initialized")
 			return nil, err
 		}
 	}
-	store, err := service.NewStorage(storageConfig, unleashClient)
+	store, err := service.NewStorage(storageConfig, canaryConfig.UnleashEnabled, unleashClient)
 	if err != nil {
 		log.Error().Err(err).Msg("Error initializing the storage")
 		return nil, err

--- a/tests/conditions/canary/rules.json
+++ b/tests/conditions/canary/rules.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.0",
+    "rules":
+    [
+        {
+            "conditions": [
+                {
+                    "type": "alert_is_firing",
+                    "alert": {
+                        "name": "SamplesImagestreamImportFailing"
+                    }
+                }
+            ],
+            "gathering_functions": {
+                "logs_of_namespace": {
+                    "namespace": "openshift-cluster-samples-operator",
+                    "tail_lines": 100
+                },
+                "image_streams_of_namespace": {
+                    "namespace": "openshift-cluster-samples-operator"
+                }
+            }
+        }
+    ]
+}

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -7,6 +7,8 @@ enable_cors = false
 rules_path = "tests/conditions"
 remote_configuration = "./tests/rapid-recommendations"
 cluster_mapping = "./tests/rapid-recommendations/cluster-mapping.json"
+
+[canary]
 unleash_enabled = false
 unleash_url = "http://fake-unleash-url/api"
 unleash_token = ""

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -7,6 +7,11 @@ enable_cors = false
 rules_path = "tests/conditions"
 remote_configuration = "./tests/rapid-recommendations"
 cluster_mapping = "./tests/rapid-recommendations/cluster-mapping.json"
+unleash_enabled = false
+unleash_url = "http://fake-unleash-url/api"
+unleash_token = ""
+unleash_toggle = "insights-operator-gathering-conditions-service"
+unleash_app = "default"
 
 [sentry]
 dsn = "https://daca7436565e4580a85102b9ede9a177@sentry.devshift.net/1020"

--- a/tests/rapid-recommendations/canary/bug_workaround.json
+++ b/tests/rapid-recommendations/canary/bug_workaround.json
@@ -1,0 +1,23 @@
+{
+  "conditional_gathering_rules": [
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "BugWorkaround"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "BugWorkaround",
+          "container": "bug-workaround",
+          "tail_lines": 50
+        }
+      }
+    }
+  ],
+  "container_logs": [],
+  "version": "1.1.0"
+}

--- a/tests/rapid-recommendations/canary/config_default.json
+++ b/tests/rapid-recommendations/canary/config_default.json
@@ -1,0 +1,161 @@
+{
+  "conditional_gathering_rules": [
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "AlertmanagerFailedReload"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "AlertmanagerFailedReload",
+          "container": "alertmanager",
+          "tail_lines": 50
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "AlertmanagerFailedToSendAlerts"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "AlertmanagerFailedToSendAlerts",
+          "tail_lines": 50,
+          "container": "alertmanager"
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "APIRemovedInNextEUSReleaseInUse"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "api_request_counts_of_resource_from_alert": {
+          "alert_name": "APIRemovedInNextEUSReleaseInUse"
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "KubePodCrashLooping"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "KubePodCrashLooping",
+          "tail_lines": 20,
+          "previous": true
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "KubePodNotReady"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "KubePodNotReady",
+          "tail_lines": 100
+        },
+        "pod_definition": {
+          "alert_name": "KubePodNotReady"
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "PrometheusOperatorSyncFailed"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "PrometheusOperatorSyncFailed",
+          "tail_lines": 50,
+          "container": "prometheus-operator"
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "PrometheusTargetSyncFailure"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "PrometheusTargetSyncFailure",
+          "container": "prometheus",
+          "tail_lines": 50
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "SamplesImagestreamImportFailing"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "logs_of_namespace": {
+          "namespace": "openshift-cluster-samples-operator",
+          "tail_lines": 100
+        },
+        "image_streams_of_namespace": {
+          "namespace": "openshift-cluster-samples-operator"
+        }
+      }
+    },
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "ThanosRuleQueueIsDroppingAlerts"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "ThanosRuleQueueIsDroppingAlerts",
+          "container": "thanos-ruler",
+          "tail_lines": 50
+        }
+      }
+    }
+  ],
+  "container_logs": [],
+  "version": "1.1.0"
+}

--- a/tests/rapid-recommendations/canary/empty.json
+++ b/tests/rapid-recommendations/canary/empty.json
@@ -1,0 +1,5 @@
+{
+  "conditional_gathering_rules": [],
+  "container_logs": [],
+  "version": "1.1.0"
+}

--- a/tests/rapid-recommendations/canary/experimental_1.json
+++ b/tests/rapid-recommendations/canary/experimental_1.json
@@ -1,0 +1,23 @@
+{
+  "conditional_gathering_rules": [
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "Experimental1"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "Experimental1",
+          "container": "experimental1",
+          "tail_lines": 50
+        }
+      }
+    }
+  ],
+  "container_logs": [],
+  "version": "1.1.0"
+}

--- a/tests/rapid-recommendations/canary/experimental_2.json
+++ b/tests/rapid-recommendations/canary/experimental_2.json
@@ -1,0 +1,23 @@
+{
+  "conditional_gathering_rules": [
+    {
+      "conditions": [
+        {
+          "type": "alert_is_firing",
+          "alert": {
+            "name": "Experimental2"
+          }
+        }
+      ],
+      "gathering_functions": {
+        "containers_logs": {
+          "alert_name": "Experimental2",
+          "container": "experimental2",
+          "tail_lines": 50
+        }
+      }
+    }
+  ],
+  "container_logs": [],
+  "version": "1.1.0"
+}

--- a/tests/rest/rules_endpoint.go
+++ b/tests/rest/rules_endpoint.go
@@ -22,8 +22,6 @@ import (
 	"github.com/verdverm/frisby"
 )
 
-const userAgentWithClusterID = "insights-operator/4.14.27-$Format:%H$ cluster/9abc1e7a-d834-4c6d-99b1-826399958d1c"
-
 // Rule data type definition based on original JSON schema
 type Rule struct {
 	Conditions         []interface{} `json:"conditions,omitempty"`
@@ -73,7 +71,7 @@ func checkResponse(f *frisby.Frisby, response Payload) {
 
 // checkRulesEndpoint tests if rules endpoint is reachable and that it returns expected data
 func checkRulesEndpoint() {
-	f := frisby.Create("Check the /gathering-rules endpoint").Get(apiURL+"api/gathering/gathering_rules").SetHeader("User-Agent", userAgentWithClusterID)
+	f := frisby.Create("Check the /gathering-rules endpoint").Get(apiURL + "api/gathering/gathering_rules")
 	f.Send()
 	f.ExpectStatus(200)
 	f.ExpectHeader(contentTypeHeader, "application/json")

--- a/tests/rest/rules_endpoint.go
+++ b/tests/rest/rules_endpoint.go
@@ -22,6 +22,8 @@ import (
 	"github.com/verdverm/frisby"
 )
 
+const userAgentWithClusterID = "insights-operator/4.14.27-$Format:%H$ cluster/9abc1e7a-d834-4c6d-99b1-826399958d1c"
+
 // Rule data type definition based on original JSON schema
 type Rule struct {
 	Conditions         []interface{} `json:"conditions,omitempty"`
@@ -71,7 +73,7 @@ func checkResponse(f *frisby.Frisby, response Payload) {
 
 // checkRulesEndpoint tests if rules endpoint is reachable and that it returns expected data
 func checkRulesEndpoint() {
-	f := frisby.Create("Check the /gathering-rules endpoint").Get(apiURL + "api/gathering/gathering_rules")
+	f := frisby.Create("Check the /gathering-rules endpoint").Get(apiURL+"api/gathering/gathering_rules").SetHeader("User-Agent", userAgentWithClusterID)
 	f.Send()
 	f.ExpectStatus(200)
 	f.ExpectHeader(contentTypeHeader, "application/json")


### PR DESCRIPTION
# Description

Add canary rollout to gradually release new versions of io-gathering-conditions.

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Documentation update
- Configuration update

## Testing steps

Canary rollouts work locally (as Docker container) with local Unleash instance.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
