### PR TITLE
Fix duplicated metric in dashboard

### DIFF
--- a/dashboards/grafana-dashboard-io-gathering-service.configmap.yaml
+++ b/dashboards/grafana-dashboard-io-gathering-service.configmap.yaml
@@ -219,7 +219,7 @@ data:
                 "uid": "PC1EAC84DCBBF0697"
               },
               "editorMode": "code",
-              "expr": "sum(increase(gathering_conditions_remote_configuration_version_total[1m])) by (version)",
+              "expr": "sum(increase(gathering_conditions_remote_configuration_version_total{service=\"ccx-data-pipeline-prometheus-exporter\"}[1m])) by (version)",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{version}}",
@@ -315,7 +315,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(io_gathering_remote_configuration[15m])) by(version) / sum(increase(gathering_conditions_remote_configuration_version_total[15m])) by(version)",
+              "expr": "sum(increase(io_gathering_remote_configuration[15m])) by(version) / sum(increase(gathering_conditions_remote_configuration_version_total{service=\"ccx-data-pipeline-prometheus-exporter\"}[15m])) by(version)",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,


### PR DESCRIPTION
# Description

In https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/117408 the [new metric](https://github.com/RedHatInsights/insights-ccx-messaging/pull/252/files) was [added to dvo-extractor](https://github.com/RedHatInsights/dvo-extractor/compare/561db7d1fc14f0559c655a3912a54c4fe81566fa...b2c71061c15b89c55df82a54f4eeb7bc2aea0cdf) and generated a missmatch in the dashboard, as we started seeing x2 archives processed vs remote configurations requested.

These changes filters the metrics by service just taking into account the ccx-data-pipeline ones.

Discussed in [Slack](https://redhat-internal.slack.com/archives/C06TMSN621F/p1727072797261489).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

UI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
