### PR TITLE
[CCXDEV-13091] Use parsed cluster ID instead of User-Agent

### DIFF
--- a/internal/service/common_test.go
+++ b/internal/service/common_test.go
@@ -135,6 +135,7 @@ var (
 
 	stableUserAgent = "insights-operator/4.14.27-$Format:%H$ cluster/9abc1e7a-d834-4c6d-99b1-826399958d1c"
 	canaryUserAgent = "insights-operator/4.14.27-$Format:%H$ cluster/f9fbc65a-52e6-4781-979d-1d5c6b124f9b"
+	canaryClusterID = "f9fbc65a-52e6-4781-979d-1d5c6b124f9b"
 )
 
 type mockStorage struct {

--- a/internal/service/storage.go
+++ b/internal/service/storage.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/Unleash/unleash-client-go/v4"
@@ -179,13 +180,14 @@ func NewStorage(storageConfig StorageConfig, unleashEnabled bool, unleashClient 
 func (s *Storage) ReadConditionalRules(r *http.Request, path string) []byte {
 	log.Debug().Str("path to resource", path).Msg("Finding resource")
 	version := StableVersion
+	clusterID := GetClusterID(r)
 	if s.unleashEnabled {
 		// We use User-Agent header to decide between stable and canary version (header contains cluster ID)
-		if s.unleashClient.IsCanary(r.UserAgent()) {
-			log.Debug().Str("canary argument", r.UserAgent()).Msg("Served canary version of rules")
+		if s.unleashClient.IsCanary(clusterID) {
+			log.Debug().Str("canary argument", clusterID).Msg("Served canary version of rules")
 			version = CanaryVersion
 		} else {
-			log.Debug().Str("canary argument", r.UserAgent()).Msg("Served stable version of rules")
+			log.Debug().Str("canary argument", clusterID).Msg("Served stable version of rules")
 		}
 	}
 	conditionalRulesPath := fmt.Sprintf("%s/%s/%s", s.conditionalRulesPath, version, path)
@@ -196,13 +198,14 @@ func (s *Storage) ReadConditionalRules(r *http.Request, path string) []byte {
 func (s *Storage) ReadRemoteConfig(r *http.Request, path string) []byte {
 	log.Debug().Str("path to resource", path).Msg("Finding resource")
 	version := StableVersion
+	clusterID := GetClusterID(r)
 	if s.unleashEnabled {
 		// We use User-Agent header to decide between stable and canary version (header contains cluster ID)
-		if s.unleashClient.IsCanary(r.UserAgent()) {
-			log.Debug().Str("canary argument", r.UserAgent()).Msg("Served canary version of remote configurations")
+		if s.unleashClient.IsCanary(clusterID) {
+			log.Debug().Str("canary argument", clusterID).Msg("Served canary version of remote configurations")
 			version = CanaryVersion
 		} else {
-			log.Debug().Str("canary argument", r.UserAgent()).Msg("Served stable version of remote configurations")
+			log.Debug().Str("canary argument", clusterID).Msg("Served stable version of remote configurations")
 		}
 	}
 	remoteConfigPath := fmt.Sprintf("%s/%s/%s", s.remoteConfigurationPath, version, path)
@@ -264,4 +267,15 @@ func (s *Storage) readFile(path string) ([]byte, error) {
 	s.cache.Set(path, data)
 
 	return data, nil
+}
+
+func GetClusterID(r *http.Request) string {
+	userAgent := r.UserAgent()
+	if !strings.Contains(userAgent, "cluster/") {
+		err := errors.New("UserAgent does not contain cluster ID")
+		log.Error().Str("UserAgent", userAgent).Err(err).Msg("Failed to retrieve cluster ID")
+		return ""
+	}
+	_, clusterID, _ := strings.Cut(userAgent, "cluster/")
+	return clusterID
 }

--- a/internal/service/storage.go
+++ b/internal/service/storage.go
@@ -277,5 +277,9 @@ func GetClusterID(r *http.Request) string {
 		return ""
 	}
 	_, clusterID, _ := strings.Cut(userAgent, "cluster/")
+
+	// Get rid of any text that would follow after cluster ID
+	clusterID = strings.Split(clusterID, " ")[0]
+	clusterID = strings.Split(clusterID, ",")[0]
 	return clusterID
 }

--- a/internal/service/storage_test.go
+++ b/internal/service/storage_test.go
@@ -35,7 +35,7 @@ const (
 type MockUnleashClient struct{}
 
 func (c *MockUnleashClient) IsCanary(canaryArgument string) bool {
-	return canaryArgument == canaryUserAgent
+	return canaryArgument == canaryClusterID
 }
 
 func TestNewStorage(t *testing.T) {
@@ -281,4 +281,26 @@ func TestReadRemoteConfigurationCanaryRollout(t *testing.T) {
 			checkRemoteConfig(t, storage, tt.remoteConfigFile, tt.expectedRemoteConfig, req)
 		})
 	}
+}
+
+func TestGetClusterID(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	assert.NoError(t, err)
+
+	req.Header.Add("Authorization", "Bearer token")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", stableUserAgent)
+
+	clusterID := service.GetClusterID(req)
+	assert.Equal(t, clusterID, "9abc1e7a-d834-4c6d-99b1-826399958d1c")
+}
+
+func TestGetClusterIDHeaderWithoutClusterID(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	assert.NoError(t, err)
+	req.Header.Add("Authorization", "Bearer token")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "Go-http-client/1.1")
+	clusterID := service.GetClusterID(req)
+	assert.Equal(t, clusterID, "")
 }


### PR DESCRIPTION
# Description

Parsing cluster ID might help us detect issues in case the format of User-Agent changes. After team discussion, I am getting it back.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Service runs locally without issues.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
