### PR TITLE
Set config canary version to 1.1.1

### DIFF
--- a/get_conditions.sh
+++ b/get_conditions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 STABLE_VERSION=1.1.0
-CANARY_VERSION=1.1.0
+CANARY_VERSION=1.1.1
 
 # Clone the conditions repo and build it to gather the conditions
 if [ ! -d 'insights-operator-gathering-conditions' ]; then git clone https://github.com/RedHatInsights/insights-operator-gathering-conditions; fi


### PR DESCRIPTION


# Description

Config version 1.1.1 is identical to 1.1.0. The purpose of this change is to validate the release process documentation without actually changing anything.

## Type of change

- Configuration update

## Testing steps

None.

## Checklist

Not applicable?

* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
