### PR TITLE
Revert "Set config canary version to 1.1.1"

### DIFF
--- a/get_conditions.sh
+++ b/get_conditions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 STABLE_VERSION=1.1.0
-CANARY_VERSION=1.1.1
+CANARY_VERSION=1.1.0
 
 # Clone the conditions repo and build it to gather the conditions
 if [ ! -d 'insights-operator-gathering-conditions' ]; then git clone https://github.com/RedHatInsights/insights-operator-gathering-conditions; fi


### PR DESCRIPTION


# Description

This reverts commit d24d74983b834a6f57a3c1a743e2997edec7d18b.

It sets the config canary version back to 1.1.0. Both 1.1.0 and 1.1.1 versions are the same commit. The build procedure deployed 1.1.1 still as 1.1.0.

Part of INSIGHTOCP-1953.

## Type of change

- Configuration update

## Testing steps

https://github.com/RedHatInsights/insights-operator-gathering-conditions/releases/tag/1.1.0

## Checklist

Not applicable.