### PR TITLE
Set config canary version to 1.1.3

### DIFF
--- a/get_conditions.sh
+++ b/get_conditions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 STABLE_VERSION=1.1.2
-CANARY_VERSION=1.1.2
+CANARY_VERSION=1.1.3
 
 # Clone the conditions repo and build it to gather the conditions
 if [ ! -d 'insights-operator-gathering-conditions' ]; then git clone https://github.com/RedHatInsights/insights-operator-gathering-conditions; fi


### PR DESCRIPTION
# Description

Canary rollout of `insights-operator-gathering-conditions-1.1.3`.

INSIGHTOCP-1954

## Type of change

- Configuration update

## Testing steps

* https://github.com/RedHatInsights/insights-operator-gathering-conditions/releases/tag/1.1.2
* https://github.com/RedHatInsights/insights-operator-gathering-conditions/releases/tag/1.1.3

## Checklist

N/A