### PR TITLE
Drop legacy building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS conditions
 
-RUN microdnf install --nodocs -y jq git python3.11 python3.11-pip go-toolset
+RUN microdnf install --nodocs -y git python3.11 python3.11-pip go-toolset
 
 COPY get_conditions.sh .
 

--- a/get_conditions.sh
+++ b/get_conditions.sh
@@ -16,14 +16,6 @@ build() {
   rm -r build
 }
 
-build_legacy() {
-  ./build.sh
-  cp -r build/v1 "../conditions/$1"
-  cp -r build/v2 "../remote-configurations/$1"
-  cp build/cluster-mapping.json "../remote-configurations/$1/cluster_version_mapping.json"
-  rm -r build
-}
-
 # Clone the conditions repo and build it to gather the conditions
 if [ ! -d 'insights-operator-gathering-conditions' ]; then git clone https://github.com/RedHatInsights/insights-operator-gathering-conditions; fi
 mkdir -p conditions
@@ -35,17 +27,9 @@ python3.11 -m venv .env
 source .env/bin/activate
 
 git checkout ${STABLE_VERSION}
-if [ -f build.py ]; then
-  build "stable"
-else
-  build_legacy "stable"
-fi
+build "stable"
 
 git checkout ${CANARY_VERSION}
-if [ -f build.py ]; then
-  build "canary"
-else
-  build_legacy "canary"
-fi
+build "canary"
 
 rm -r .env


### PR DESCRIPTION
# Description

Now that a new build script has been implemented in the gathering conditions repo
and it is being used for all versions, we can remove the old code related to the legacy building system.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Configuration update

## Testing steps



## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
