### PR TITLE
Run golangci-lint with fix only in makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,5 +32,3 @@ formatters:
   enable:
     - gofmt
     - goimports
-issues:
-    fix: true

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ fmt: install_golangci-lint ## Run go formatting
 
 lint: install_golangci-lint ## Run go liting
 	@echo "Running go linting"
-	golangci-lint run
+	golangci-lint run --fix
 
 shellcheck: ## Run shellcheck
 	./shellcheck.sh


### PR DESCRIPTION
# Description

Having it in the config fail causes the CI job to
not fail when there are issues than can fixed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
