### PR TITLE
Fix on-push job configuration

### DIFF
--- a/.tekton/io-gathering-service-push.yaml
+++ b/.tekton/io-gathering-service-push.yaml
@@ -536,8 +536,10 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-      - name: IMAGE
+      - name: IMAGE_URL
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
# Description

The `apply-tags` task on the Tekton configuration files needs to be updated in both on-pull-request and on-push configuration files. I missed the later, so this PR fixes this problem.

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
