### PR TITLE
[CCXDEV-15370] conf: remove no longer used cloudwatch variable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -38,4 +38,3 @@ aws_region = "us-east-1"
 log_group = "platform-dev"
 stream_name = "io-gathering-service"
 debug = false
-create_stream_if_not_exists = false

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -72,8 +72,6 @@ objects:
               value: ${CLOUDWATCH_DEBUG}
             - name: INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__CLOUDWATCH__STREAM_NAME
               value: ${IOGCS_LOG_STREAM}
-            - name: INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__CLOUDWATCH__CREATE_STREAM_IF_NOT_EXISTS
-              value: ${CREATE_STREAM_IF_NOT_EXISTS}
             - name: INSIGHTS_OPERATOR_GATHERING_CONDITIONS_SERVICE__CLOUDWATCH__AWS_REGION
               valueFrom:
                 secretKeyRef:
@@ -211,8 +209,6 @@ parameters:
   required: true
 - name: IOGCS_LOG_STREAM
   value: $HOSTNAME
-- name: CREATE_STREAM_IF_NOT_EXISTS
-  value: "true"
 - name: CPU_REQUEST
   value: '100m'
 - name: MEMORY_REQUEST


### PR DESCRIPTION
# Description

IO utils was updated automatically and this variable is no longer used, so I'm cleaning it up.

## Type of change

- Configuration update

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
